### PR TITLE
Fix to resolve an error when creating a new table object that doesn't use default primary index format

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -78,6 +78,7 @@ export default class Table {
                 [primary.hash]: { value: '_unique:${' + primary.hash + '}'},
                 [primary.sort]: { value: '_unique:'},
             },
+            indexes: this.indexes,
             timestamps: false
         })
         this.generic = new Model(this, '_Generic', {
@@ -85,6 +86,7 @@ export default class Table {
                 [primary.hash]: {},
                 [primary.sort]: {},
             },
+            indexes: this.indexes,
             timestamps: false
         })
 


### PR DESCRIPTION
Version 1.0.1 

Error: "Cannot set property 'required' of undefined"

When using primary index that doesn't conform to { hash: 'pk', sort: 'sk' }



We have an existing DynamoDB table following the single table design pattern, that uses the following indexes:
```
primary: { hash: 'PK', sort: 'SK' },
"GSI1PK-GSI1SK-index":	{ hash: 'GSI1PK', sort: 'GSI1SK' },
"GSI2PK-index": { hash: 'GSI2PK'}
```

When evaluating OneTable on this table I receive the following error when instantiating the `Table` object:

```
"name":"TypeError",
"message": "Cannot set property 'required' of undefined",
"stack":"TypeError: Cannot set property 'required' of undefined at Model.prepModel node_modules/dynamodb-onetable/dist/mjs/Model.js:124:50
```

Here's the example code to reproduce

```
...

const indexes = {
	primary: { hash: 'PK', sort: 'SK' },
	"GSI1PK-GSI1SK-index":	{ hash: 'GSI1PK', sort: 'GSI1SK' },
	"GSI2PK-index": { hash: 'GSI2PK'}
};

const table = new Table({
    client: client,
    name: 'example',
	schema: {
		indexes: indexes,
		models: {}
	}
});

export const Project = new Model(table, 'Project', {

	indexes: indexes,
	fields: {
		PK:          { value: 'ACCOUNT#${Owner}' },
		SK:          { value: 'PROJECT#${Owner}#${Slug}' },
		UUID:        { type: String, uuid: true, validate: /^[0-9A-F]{32}$/i, },
		Name:        { type: String, required: true},
		Owner:       { type: String, required: true},
		Slug:        { type: String, required: true},
		CreatedAt:   { type: String, required: true},
		ModifiedAt:  { type: String, required: true},
		GSI1PK: { value: 'ACCOUNT#${Owner}' },
		GSI1SK: { value: 'PROJECT#${Owner}#${Slug}' },
		GSI2PK: { value: '${UUID}' }
	}
})
```


I believe the error is cause when the `_Unique` and `_Generic` Models are created, as the `indexes` object is not passed through, therefore this reverts to `DefaultIndexes` on line 79 of `Model.js`

Original: (`Table.js` ln 65 - 78)

```
this.unique = new Model(this, '_Unique', {
    fields: {
        [primary.hash]: { value: '_unique:${' + primary.hash + '}' },
        [primary.sort]: { value: '_unique:' },
    },
    timestamps: false
});
this.generic = new Model(this, '_Generic', {
    fields: {
        [primary.hash]: {},
        [primary.sort]: {},
    },
    timestamps: false
});
```

Updated:

```
this.unique = new Model(this, '_Unique', {
    fields: {
        [primary.hash]: { value: '_unique:${' + primary.hash + '}' },
        [primary.sort]: { value: '_unique:' },
    },
    indexes: this.indexes,
    timestamps: false
});
this.generic = new Model(this, '_Generic', {
    fields: {
        [primary.hash]: {},
        [primary.sort]: {},
    },
    indexes: this.indexes,
    timestamps: false
});
```
