### PR TITLE
typo in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ const MySchema = {
 Alternatively, you can define models one by one:
 
 ```javascript
-const Card = new Model(table, {
-    name: 'Card',
+const Card = new Model(table, 'Card', {
     fields: { /* Model schema field definitions */ }
 })
 ```


### PR DESCRIPTION
The following refers to an incorrect (old maybe?) way to create a model 

```javascript
const Card = new Model(table, {
    name: 'Card',
    fields: { /* Model schema field definitions */ }
})
```

This should be

```javascript
const Card = new Model(table, 'Card', {
    fields: { /* Model schema field definitions */ }
})
```
