### PR TITLE
Fix for ERR_MODULE_NOT_FOUND within lambda node14.x runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@
     dynamodb-onetable - DynamoDB wrapper for single table patterns
 */
 
-import { Expression } from './Expression'
-import { Model } from './Model'
-import { Table } from './Table'
+import { Expression } from './Expression.js'
+import { Model } from './Model.js'
+import { Table } from './Table.js'
 
 export { Expression, Model, Table }


### PR DESCRIPTION
Having been working locally without issue, I've now deployed to an AWS lambda function using the `node14.x` runtime. 

As I'm working in node14 my code uses import statements, rather than require. e.g. `import {Table, Model} from 'dynamodb-onetable';`

Invoking the lambda I receive an `ERR_MODULE_NOT_FOUND` not found error:

```
{
    "errorType": "Error",
    "errorMessage": "Cannot find module '/var/task/node_modules/dynamodb-onetable/dist/mjs/Expression' imported from /var/task/node_modules/dynamodb-onetable/dist/mjs/index.js",
    "code": "ERR_MODULE_NOT_FOUND",
    "stack": [
        "Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/node_modules/dynamodb-onetable/dist/mjs/Expression' imported from /var/task/node_modules/dynamodb-onetable/dist/mjs/index.js",
        "    at finalizeResolution (internal/modules/esm/resolve.js:276:11)",
        "    at moduleResolve (internal/modules/esm/resolve.js:699:10)",
        "    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:810:11)",
        "    at Loader.resolve (internal/modules/esm/loader.js:86:40)",
        "    at Loader.getModuleJob (internal/modules/esm/loader.js:230:28)",
        "    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:56:40)",
        "    at link (internal/modules/esm/module_job.js:55:36)"
    ]
}
```

I'm not entirely certain why this works for me locally (maybe I'm running `--experimental-specifier-resolution=node` flag 🤷‍♂️). But it seems the lambda `node14.x` runtime definitely doesn't allow ESM imports without the file extension. 

Modified `src/index.js` to specify the file extensions which resolved my issue. 




 




