### PR TITLE
Fix unmarshall failure when LastEvaluatedKey is empty

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -335,7 +335,11 @@ export class Model {
         }
         if (op == 'find' || op == 'scan') {
             if (metrics) {
-                items.start = this.table.unmarshall(result.LastEvaluatedKey)
+                if (result.LastEvaluatedKey) {
+                    items.start = this.table.unmarshall(result.LastEvaluatedKey)
+                } else {
+                    items.start = result.LastEvaluatedKey
+                }
             }
             if (result.LastEvaluatedKey) {
                 /*


### PR DESCRIPTION
Discovered this error when setting a `limit` value param that is greater than the actual record count