### PR TITLE
Initialize typeField value for find method.

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -543,6 +543,8 @@ export class Model {
     }
 
     /* private */ async queryItems(properties = {}, params = {}) {
+        properties = Object.assign({}, properties)
+        properties[this.typeField] = this.name        
         let expression = new Expression(this, 'find', properties, params)
         return await this.run('find', expression)
     }


### PR DESCRIPTION
 It allows do: Model.find({ },{ }) without pasing Model.find({ _type: 'Role',  },{ });

````javascript
const RoleModel = new Model(table, 'Role', {
  fields: {
    pk: { value: '${_type}' },
    sk: { value: '${_type}:${id}' },
    id: { type: String, ulid: true, required: true },
    name: { type: String, required: true },
    permissions: { type: Array, required: true },
  },
});

const roles = await RoleModel.find({ },{ limit: 3, parse: true });
`
