### PR TITLE
move typeField from low level queryItems to find

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -463,6 +463,8 @@ export class Model {
     async find(properties = {}, params = {}) {
         this.checkArgs(properties, params)
         params = Object.assign({parse: true, high: true}, params)
+        properties = Object.assign({}, properties)
+        properties[this.typeField] = this.name
         return await this.queryItems(properties, params)
     }
 
@@ -574,8 +576,6 @@ export class Model {
     }
 
     /* private */ async queryItems(properties = {}, params = {}) {
-        properties = Object.assign({}, properties)
-        properties[this.typeField] = this.name
         let expression = new Expression(this, 'find', properties, params)
         return await this.run('find', expression)
     }


### PR DESCRIPTION
I tried this example from readme
```
//  Fetch an item collection for Acme
let items = await table.queryItems({pk: 'account:AcmeCorp'}, {parse: true})

//  Group items into arrays by model type
items = db.groupByType(items)
```
and it doesn't work, because queryItems applied filter by _type = "Generic"

It works with scanItems though.

So my proposed patch fixes it for queryItems too.

Probably the same needs to be done for putItem and updateItem, but it's harder for me right now.

Thanks for great project!


