### PR TITLE
fix: wrong path to dist file

### DIFF
--- a/Dynamo/package.json
+++ b/Dynamo/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Dynamo",
     "description": "AWS SDK V3 access for OneTable",
-    "main": "dist/cjs/Dynamo.js",
+    "main": "../dist/cjs/Dynamo.js",
     "module": "../dist/mjs/Dynamo.js",
     "types": "../dist/mjs/Dynamo.d.ts"
 }


### PR DESCRIPTION
Not sure how it worked a month ago, but right now when trying to run app through serverless it throws me an error that `main` is not found. Shouldn't this path be similar as in `mjs` case?