### PR TITLE
chore: moved missing runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
         "url": "https://github.com/sensedeep/dynamodb-onetable/issues"
     },
     "homepage": "https://github.com/sensedeep/dynamodb-onetable",
-    "devDependencies": {
+    "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.5.0",
         "@aws-sdk/util-dynamodb": "^3.5.0",
-        "aws-sdk": "^2.718.0",
+        "aws-sdk": "^2.718.0"
+    },
+    "devDependencies": {
         "@types/jest": "^26.0.19",
         "@types/node": "^14.14.16",
         "dynamo-db-local": "^4.0.2",


### PR DESCRIPTION
Moved devDependencies that are actually used during runtime. Lack of it causes apps that are using this library to fail due to missing dependencies. Without this fix it works on developer machine.

Haven't tested it that way (it failed when I deployed app to AWS Lambda) is to use `npm install --production` on app that uses `dynamodb-onetable` locally. I have verified (manually and on limited scope) that this change helps.