### PR TITLE
Enhancement: Allow local forks to use docker to run dynamodb-local

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": false,
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "trailingComma": "es5",
-  "tabWidth": 4,
-  "semi": false,
-  "singleQuote": true
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,31 @@ Please ensure pull requests adheres to the following guidelines:
 - Make sure your code style matches existing code. Soft tabs=4, no trailing spaces etc.
 - Make an individual pull request for each change. No monolithic pull requests please.
 - Work constructively with project maintainers to refine your pull request if requested.
+
+## Setup
+
+Contributions are encouraged via forked pull requests.
+
+To setup the project locally run:
+
+```
+npm install
+```
+
+You can run the test suite locally with:
+
+```
+npm test
+```
+
+If you do not have Java installed, then you can run via docker with:
+
+```
+DOCKER=true npm test
+```
+
+You can run the linter with:
+
+```
+npm run lint
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,24 +16,25 @@ Contributions are encouraged via forked pull requests.
 
 To setup the project locally run:
 
-```
+```bash
 npm install
 ```
 
 You can run the test suite locally with:
 
-```
+```bash
 npm test
 ```
 
 If you do not have Java installed, then you can run via docker with:
 
-```
-DOCKER=true npm test
+```bash
+# Specify any port
+DYNAMODB_DOCKER_PORT=12345 npm test
 ```
 
 You can run the linter with:
 
-```
+```bash
 npm run lint
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,12 @@
 All code contributions shall be made using the [MIT](https://opensource.org/licenses/MIT).
 See [Contributors Agreement](https://embedthis.com/developers/contributors.html) for full details.
 
+- [Contribution Guidelines](#contribution-guidelines)
+  - [Guide](#guide)
+  - [Running locally](#running-locally)
+
+## Guide
+
 Please ensure pull requests adheres to the following guidelines:
 
 - Search previous pull requests before making a new one, as yours may be a duplicate.
@@ -10,7 +16,7 @@ Please ensure pull requests adheres to the following guidelines:
 - Make an individual pull request for each change. No monolithic pull requests please.
 - Work constructively with project maintainers to refine your pull request if requested.
 
-## Setup
+## Running locally
 
 Contributions are encouraged via forked pull requests.
 
@@ -29,8 +35,15 @@ npm test
 If you do not have Java installed, then you can run via docker with:
 
 ```bash
-# Specify any port
-DYNAMODB_DOCKER_PORT=12345 npm test
+DOCKER=yes npm test
+```
+
+If you need to change the port, that local dynamodb runs on, then set the `PORT` environment variable.
+
+```bash
+PORT=12345 npm test
+# This is also compatible with docker
+DOCKER=true PORT=12344 npm test
 ```
 
 You can run the linter with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2878,6 +2878,12 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/commander": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+            "dev": true
+        },
         "node_modules/component-emitter": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -7505,6 +7511,94 @@
                 "node": ">=10"
             }
         },
+        "node_modules/wait-port": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.9.tgz",
+            "integrity": "sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^2.4.2",
+                "commander": "^3.0.2",
+                "debug": "^4.1.1"
+            },
+            "bin": {
+                "wait-port": "bin/wait-port.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wait-port/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/wait-port/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/wait-port/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/wait-port/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "node_modules/wait-port/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/wait-port/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/wait-port/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/walker": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -9528,7 +9622,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -11674,7 +11769,8 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "26.0.0",
@@ -13820,7 +13916,8 @@
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
             "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9528,8 +9528,7 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -10019,6 +10018,12 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+            "dev": true
         },
         "component-emitter": {
             "version": "1.3.0",
@@ -11669,8 +11674,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "26.0.0",
@@ -13652,6 +13656,75 @@
                 "xml-name-validator": "^3.0.0"
             }
         },
+        "wait-port": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.9.tgz",
+            "integrity": "sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "commander": "^3.0.2",
+                "debug": "^4.1.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "walker": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -13747,8 +13820,7 @@
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
             "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
                 "eslint": "^7.25.0",
                 "jest": "^26.6.3",
                 "ts-jest": "^26.4.4",
-                "typescript": "^4.1.3"
+                "typescript": "^4.1.3",
+                "wait-port": "^0.2.9"
             },
             "engines": {
                 "node": ">=12.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         "eslint": "^7.25.0",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
-        "typescript": "^4.1.3"
+        "typescript": "^4.1.3",
+        "wait-port": "^0.2.9"
     },
     "files": [
         "dist/",

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -1,14 +1,41 @@
 /*
     Setup -- start dynamodb instance
  */
+import { spawn } from 'child_process'
 import DynamoDbLocal from 'dynamo-db-local'
 
 const PORT = 4567
 
 module.exports = async () => {
+    let dynamodb
 
-    let dynamodb = DynamoDbLocal.spawn({port: PORT})
-    process.env.DYNAMODB_PID = dynamodb.pid
-    process.env.DYNAMODB_PORT = PORT.toString()
-    // console.log('Spawn DynamoDB', dynamodb.pid)
+    if (String(process.env.DOCKER) === 'true') {
+        const args = [`run`, `-p`, `${PORT}:8000`, `amazon/dynamodb-local`]
+        console.info('Using docker to run dynamoDB', {
+            args,
+        })
+
+        // Docker errors will be forwarded to the local terminal with
+        // stdio: inherit
+        dynamodb = spawn(`docker`, args, {
+            cwd: __dirname,
+            stdio: 'inherit',
+        })
+    } else {
+        console.info('Using local Java to run dynamoDB')
+        dynamodb = DynamoDbLocal.spawn({ port: PORT })
+    }
+
+    process.env.DYNAMODB_PID = String(dynamodb.pid)
+    process.env.DYNAMODB_PORT = String(PORT)
+
+    // When jest throws anything unhandled, ensure we kill the spawned process
+    process.on('unhandledRejection', (error) => {
+        let pid = parseInt(process.env.DYNAMODB_PID)
+        if (pid) {
+            process.kill(pid)
+        }
+    })
+
+    console.info('Spawn DynamoDB', dynamodb.pid)
 }

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -6,12 +6,18 @@ const waitPort = require('wait-port')
 import DynamoDbLocal from 'dynamo-db-local'
 
 const PORT = 4567
+const DYNAMODB_DOCKER_PORT = parseInt(process.env.DYNAMODB_DOCKER_PORT)
 
 module.exports = async () => {
     let dynamodb
 
-    if (String(process.env.DOCKER) === 'true') {
-        const args = [`run`, `-p`, `${PORT}:8000`, `amazon/dynamodb-local`]
+    if (DYNAMODB_DOCKER_PORT) {
+        const args = [
+            `run`,
+            `-p`,
+            `${DYNAMODB_DOCKER_PORT}:8000`,
+            `amazon/dynamodb-local`,
+        ]
         console.info('\nUsing docker to run dynamoDB', {
             args,
         })
@@ -25,7 +31,7 @@ module.exports = async () => {
 
         await waitPort({
             host: '0.0.0.0',
-            port: PORT,
+            port: DYNAMODB_DOCKER_PORT,
             timeout: 3000,
         })
 
@@ -36,7 +42,7 @@ module.exports = async () => {
     }
 
     process.env.DYNAMODB_PID = String(dynamodb.pid)
-    process.env.DYNAMODB_PORT = String(PORT)
+    process.env.DYNAMODB_PORT = String(DYNAMODB_DOCKER_PORT || PORT)
 
     // When jest throws anything unhandled, ensure we kill the spawned process
     process.on('unhandledRejection', (error) => {

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -2,6 +2,7 @@
     Setup -- start dynamodb instance
  */
 import { spawn } from 'child_process'
+const waitPort = require('wait-port')
 import DynamoDbLocal from 'dynamo-db-local'
 
 const PORT = 4567
@@ -11,7 +12,7 @@ module.exports = async () => {
 
     if (String(process.env.DOCKER) === 'true') {
         const args = [`run`, `-p`, `${PORT}:8000`, `amazon/dynamodb-local`]
-        console.info('Using docker to run dynamoDB', {
+        console.info('\nUsing docker to run dynamoDB', {
             args,
         })
 
@@ -21,6 +22,14 @@ module.exports = async () => {
             cwd: __dirname,
             stdio: 'inherit',
         })
+
+        await waitPort({
+            host: '0.0.0.0',
+            port: PORT,
+            timeout: 3000,
+        })
+
+        console.info('Docker is ready')
     } else {
         console.info('Using local Java to run dynamoDB')
         dynamodb = DynamoDbLocal.spawn({ port: PORT })


### PR DESCRIPTION
Morning @mobsense, and wow, thanks for this awesome library, I really enjoyed reading the docs and seeing the approach.

Your check-list for dynamoDB has gone straight onto my list of tools in notion :pray: 

## Description

- Adds docker support for running tests; this boots docker instead of a local dynamo-db for people without Java
- Adds a `.prettierrc` which enforces the documented coding standard in `CONTRIBUTING.md`
    >Make sure your code style matches existing code. Soft tabs=4, no trailing spaces etc.
- Adds directions for install, build, test, and lint for contributors.

Please, let me know any feedback, and thanks for this tool :+1:

## Demonstration

1. Setup a watcher to see what docker spawns
2. Run tests
3. Show docker spinning down afterward

![docker-running-tests](https://user-images.githubusercontent.com/30017294/129541419-5a5b532d-5b1d-42ee-925a-6b29e88ab353.gif)
