### PR TITLE
Maintenance: Specify node, and npm versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,10 @@
                 "jest": "^26.6.3",
                 "ts-jest": "^26.4.4",
                 "typescript": "^4.1.3"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {

--- a/package.json
+++ b/package.json
@@ -67,5 +67,9 @@
     "files": [
         "dist/",
         "Dynamo"
-    ]
+    ],
+    "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=7.0.0"
+    }
 }


### PR DESCRIPTION
Based on: https://github.com/sensedeep/dynamodb-onetable/pull/97#discussion_r690089307

## Changes

- Ensure that npm is version 7
- Ensure that node is at least version 12.x