### PR TITLE
Enhancement: Run CI for Node 12 and Node 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

This change means that the test suite will be required to pass for both Node 12.x and Node 14.x based builds.