### PR TITLE
FIX: Handle interpolated values in createUnique

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -527,8 +527,13 @@ export class Model {
         let {hash, sort} = this.indexes.primary
         let fields = this.block.fields
         fields = Object.values(fields).filter(f => f.unique && f.attribute != hash && f.attribute != sort)
+
+        let preparedProperties = this.prepareProperties('put', properties, params);
+        // Is expression necessary here? In my testing it isn't but prepareProperties suggests its necessary
+        let uniqueExpression = new Expression(this, 'put', preparedProperties, params);
         for (let field of fields) {
-            await this.table.uniqueModel.create({pk: `${this.name}:${field.attribute}:${properties[field.name]}`}, {
+            // TODO: Switch to using the table delimiter
+            await this.table.uniqueModel.create({pk: `${this.name}:${field.attribute}:${uniqueExpression.properties[field.name]}`}, {
                 transaction,
                 exists: false,
                 return: 'NONE',

--- a/test/schemas/uniqueSchema.ts
+++ b/test/schemas/uniqueSchema.ts
@@ -7,11 +7,12 @@ export default {
     },
     models: {
         User: {
-            pk:         { type: String, value: 'user#${id}' },
-            sk:         { type: String, value: 'user#' },
-            id:         { type: String, uuid: true },
-            name:       { type: String },
-            email:      { type: String, unique: true },
+            pk:           { type: String, value: 'user#${id}' },
+            sk:           { type: String, value: 'user#' },
+            id:           { type: String, uuid: true },
+            name:         { type: String },
+            email:        { type: String, unique: true },
+            interpolated: { type: String, value: "${name}:${email}", unique: true },
         }
     }
 }

--- a/test/unique.ts
+++ b/test/unique.ts
@@ -34,7 +34,12 @@ test('Create user 1', async() => {
     expect(user).toMatchObject(props)
 
     let items = await table.scanItems()
-    expect(items.length).toBe(2)
+    expect(items.length).toBe(3)
+
+    let unique = items.find((item) => {
+        return item.pk.S === 'User:interpolated:Peter Smith:peter@example.com'
+    });
+    expect(unique).toBeDefined();
 })
 
 test('Create user 2', async() => {
@@ -46,7 +51,7 @@ test('Create user 2', async() => {
     expect(user).toMatchObject(props)
 
     let items = await table.scanItems()
-    expect(items.length).toBe(4)
+    expect(items.length).toBe(6)
 })
 
 test('Create non-unique user', async() => {
@@ -59,7 +64,7 @@ test('Create non-unique user', async() => {
     }).rejects.toThrow()
 
     let items = await table.scanItems()
-    expect(items.length).toBe(4)
+    expect(items.length).toBe(6)
 })
 
 test('Remove user 1', async() => {
@@ -71,7 +76,7 @@ test('Remove user 1', async() => {
     expect(users.length).toBe(1)
 
     let items = await table.scanItems()
-    expect(items.length).toBe(2)
+    expect(items.length).toBe(3)
 })
 
 test('Remove all users', async() => {


### PR DESCRIPTION
When using an interpolated value as a unique attribute, this method was
saving `undefined` on the `pk`. This commit updates the logic to run the
interpolation before extracting the unique field value from properties.

This commit also adds a test for this case.

NOTE: It isn't clear that `new Expression` is required. Comments above
`prepareProperties` suggest that it is, but manual testing suggests
otherwise.