### PR TITLE
fix .find and .scan types

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -177,29 +177,29 @@ export class Paged<T> extends Array {
 export type AnyModel = {
     constructor(table: any, name: string, options?: ModelConstructorOptions): AnyModel;
     create(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
-    find(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity[]>>;
+    find(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     get(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
     init(properties?: OneProperties, params?: OneParams): AnyEntity;
     remove(properties: OneProperties, params?: OneParams): Promise<void>;
-    scan(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity[]>>;
+    scan(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     update(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
 
     // deleteItem(properties: OneProperties, params?: OneParams): Promise<void>;
     // getItem(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
     // initItem(properties?: OneProperties, params?: OneParams): AnyEntity;
     // putItem(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
-    // queryItems(properties: OneProperties, params?: OneParams): Promise<Paged<AnyEntity[]>>;
-    // scanItems(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity[]>>;
+    // queryItems(properties: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
+    // scanItems(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     // updateItem(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
 };
 
 export class Model<T> {
     constructor(table: any, name: string, options?: ModelConstructorOptions);
     create(properties: T, params?: OneParams): Promise<T>;
-    find(properties?: T, params?: OneParams): Promise<Paged<T[]>>;
+    find(properties?: T, params?: OneParams): Promise<Paged<T>>;
     get(properties: T, params?: OneParams): Promise<T>;
     init(properties?: T, params?: OneParams): T;
     remove(properties: T, params?: OneParams): Promise<void>;
-    scan(properties?: T, params?: OneParams): Promise<Paged<T[]>>;
+    scan(properties?: T, params?: OneParams): Promise<Paged<T>>;
     update(properties: T, params?: OneParams): Promise<T>;
 }


### PR DESCRIPTION
This is to fix the following issue.

https://github.com/sensedeep/dynamodb-onetable/issues/115