### PR TITLE
fix: Fix unique attribute creation when hash and sort key are different

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -502,7 +502,7 @@ export class Model {
         for (let field of fields) {
             let pk = `_unique#${this.name}#${field.attribute}#${properties[field.name]}`
             let sk = '_unique#'
-            await this.schema.uniqueModel.create({pk, sk}, {transaction, exists: false, return: 'NONE'})
+            await this.schema.uniqueModel.create({[this.hash]: pk,[this.sort]: sk}, {transaction, exists: false, return: 'NONE'})
         }
         let item = await this.putItem(properties, params)
 


### PR DESCRIPTION
It looks like the when creating the item for the unique attribute `onetable` does not use the custom hash and sort keys.