### PR TITLE
Add support for params in group by

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage
 test/proto.ts
 test/schemas/protoSchema.ts
 *.keep
+.idea
+yarn.lock

--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -55,7 +55,7 @@ export class Table {
     getKeys(): Promise<OneIndexSchema>;
     getModel<T>(name: string): Model<T>;
     getCurrentSchema(): {};
-    groupByType(items: AnyEntity[]): EntityGroup;
+    groupByType(items: AnyEntity[], params?: OneParams): EntityGroup;
     listModels(): AnyModel[];
     listTables(): string[];
     makeID(): {};

--- a/src/Table.js
+++ b/src/Table.js
@@ -623,10 +623,19 @@ export class Table {
             let type = item[this.typeField] || '_unknown'
             let list = result[type] = result[type] || []
             let model = this.schema.models[type]
-            if (Object.keys(params).length && model && model !== this.schema.uniqueModel) {
-                item = model.transformReadItem('get', item, {}, params)
+            let preparedItem
+            if(typeof params.hidden === 'boolean' && !params.hidden){
+                let fields = model.block.fields
+                preparedItem = {}
+                for (let [name, field] of Object.entries(fields)) {
+                    if (!(field.hidden && params.hidden !== true)) {
+                        preparedItem[name] = item[name]
+                    }
+                }
+            } else {
+                preparedItem = item
             }
-            list.push(item)
+            list.push(preparedItem)
         }
         return result
     }

--- a/src/Table.js
+++ b/src/Table.js
@@ -624,7 +624,7 @@ export class Table {
             let list = result[type] = result[type] || []
             let model = this.schema.models[type]
             let preparedItem
-            if(typeof params.hidden === 'boolean' && !params.hidden){
+            if (typeof params.hidden === 'boolean' && !params.hidden) {
                 let fields = model.block.fields
                 preparedItem = {}
                 for (let [name, field] of Object.entries(fields)) {

--- a/src/Table.js
+++ b/src/Table.js
@@ -617,11 +617,15 @@ export class Table {
     /*
         Convert items into a map of items by model type
     */
-    groupByType(items) {
+    groupByType(items, params={}) {
         let result = {}
         for (let item of items) {
             let type = item[this.typeField] || '_unknown'
             let list = result[type] = result[type] || []
+            let model = this.schema.models[type]
+            if (Object.keys(params).length && model && model !== this.schema.uniqueModel) {
+                item = model.transformReadItem('get', item, {}, params)
+            }
             list.push(item)
         }
         return result

--- a/test/typescript-tenant.ts
+++ b/test/typescript-tenant.ts
@@ -59,6 +59,19 @@ test('Fetch', async() => {
     expect(collection.User.length).toBe(userData.length)
 })
 
+
+test('Group by with params', async() => {
+    let items = await table.queryItems({pk: `Account#${account.id}`}, {parse: true, hidden: true})
+
+    let collection = table.groupByType(items)
+    expect(collection.Account.length).toBe(1)
+    expect(collection.Account[0]._type).toBe('Account')
+
+    collection = table.groupByType(items, {parse: true, hidden:false})
+    expect(collection.Account.length).toBe(1)
+    expect(collection.Account[0]._type).toBeUndefined()
+})
+
 test('Fetch', async() => {
     let collection = await table.fetch(['Account', 'User'], {pk: `Account#${account.id}`})
     expect(collection.Account.length).toBe(1)


### PR DESCRIPTION
To be able to use `groupByType` we need to keep the `hidden` fields, there are cases where after we group the items we want those fields to not be present.

This PR adds the ability to provide `OneParams` to `groupByType` with `{parse:true, hidden:false}` so that the items are cleaned before they are added to a group.