### PR TITLE
Improve TypeScript types for find

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -135,6 +135,29 @@ type Entity<T extends OneTypedModel> = Merge<Required<T>, Optional<T>>
  */
 export type EntityParameters<Entity> = Partial<Entity>
 
+export type EntityParametersForFind<T> = {
+    [K in keyof T]: T[K]
+        | Begins<T, K>
+        | BeginsWith<T, K>
+        | Between<T, K>
+        | LessThan<T, K>
+        | LessThanOrEqual<T, K>
+        | Equal<T, K>
+        | NotEqual<T, K>
+        | GreaterThanOrEqual<T, K>
+        | GreaterThan<T, K>
+}
+
+export type Begins<T, K extends keyof T> = { begins: T[K] }
+export type BeginsWith<T, K extends keyof T> = { begins_with: T[K] }
+export type Between<T, K extends keyof T> = { between: [T[K], T[K]] }
+export type LessThan<T, K extends keyof T> = { '<': T[K] }
+export type LessThanOrEqual<T, K extends keyof T> = { '<=': T[K] }
+export type Equal<T, K extends keyof T> = { '=': T[K] }
+export type NotEqual<T, K extends keyof T> = { '<>': T[K] }
+export type GreaterThanOrEqual<T, K extends keyof T> = { '>=': T[K] }
+export type GreaterThan<T, K extends keyof T> = { '>': T[K] }
+
 /*
     Any entity. Essentially untyped.
  */
@@ -220,7 +243,7 @@ export type AnyModel = {
 export class Model<T> {
     constructor(table: any, name: string, options?: ModelConstructorOptions);
     create(properties: EntityParameters<T>, params?: OneParams): Promise<T>;
-    find(properties?: EntityParameters<T>, params?: OneParams): Promise<Paged<T>>;
+    find(properties?: EntityParametersForFind<T>, params?: OneParams): Promise<Paged<T>>;
     get(properties: EntityParameters<T>, params?: OneParams): Promise<T | undefined>;
     init(properties?: EntityParameters<T>, params?: OneParams): T;
     remove(properties: EntityParameters<T>, params?: OneParams): Promise<void>;

--- a/test/find.ts
+++ b/test/find.ts
@@ -82,6 +82,16 @@ test('Find with where clause', async() => {
     expect(items.length).toBe(1)
 })
 
+test('List with begins_with', async() => {
+    let items = await User.find({
+        status: 'active',
+        gs3sk: { begins_with: 'User#Pa' }
+    }, {
+        index: 'gs3'
+    })
+    expect(items.length).toBe(1)
+})
+
 test('Destroy Table', async() => {
     await table.deleteTable('DeleteTableForever')
     expect(await table.exists()).toBe(false)

--- a/test/schemas/defaultSchema.ts
+++ b/test/schemas/defaultSchema.ts
@@ -7,6 +7,7 @@ export default {
         primary: { hash: 'pk', sort: 'sk' },
         gs1: { hash: 'gs1pk', sort: 'gs1sk', project: 'all' },
         gs2: { hash: 'gs2pk', sort: 'gs2sk', project: 'all' },
+        gs3: { hash: 'gs3pk', sort: 'gs3sk', project: 'all' },
     },
     models: {
         User: {
@@ -28,6 +29,10 @@ export default {
             //  Find by type
             gs2pk:      { type: String, value: 'type:${_type}' },
             gs2sk:      { type: String, value: '${_type}#${id}' },
+
+            //  List by status
+            gs3pk:      { type: String, value: '${_type}#${status}' },
+            gs3sk:      { type: String, value: '${_type}#${name}' },
         }
     }
 }

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -24,18 +24,20 @@ module.exports = async () => {
             cwd: __dirname,
             stdio: 'inherit',
         })
-
-        await waitPort({
-            host: '0.0.0.0',
-            port: PORT,
-            timeout: 3000,
-        })
-
-        console.info('Docker is ready')
     } else {
         console.info('Using local Java to run dynamoDB')
-        dynamodb = DynamoDbLocal.spawn({ port: PORT })
+        dynamodb = DynamoDbLocal.spawn({ port: PORT, stdio: 'inherit' })
     }
+
+    console.info('Spawn DynamoDB', dynamodb.pid)
+
+    await waitPort({
+        host: '0.0.0.0',
+        port: PORT,
+        timeout: 3000,
+    })
+
+    console.info('DynamoDB is ready')
 
     process.env.DYNAMODB_PID = String(dynamodb.pid)
     process.env.DYNAMODB_PORT = String(PORT)
@@ -47,6 +49,4 @@ module.exports = async () => {
             process.kill(pid)
         }
     })
-
-    console.info('Spawn DynamoDB', dynamodb.pid)
 }


### PR DESCRIPTION
This addresses #220. I've included two commits:

* **The first makes running `npm test` more robust.** Before this change, for whatever reason, an initial test run would pass, but subsequent runs would fail. There was an issue with DynamoDB being unavailable. Now, both the local Java and Docker paths wait on the port.
* **The second introduces the new types for `find`.** There are probably other types we can improve, but I figure we can tackle those in separate pull requests. I added just a minimal test that the TypeScript types can be used (it's a "list" test that simulates how I use GSIs in my application).