### PR TITLE
Feature: better enum typing

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -26,7 +26,7 @@ export type OneIndexSchema = {
     hash?: string,
     sort?: string,
     description?: string,
-    project?: string | string[],
+    project?: string | readonly string[],
     follow?: boolean,
 };
 
@@ -36,7 +36,7 @@ export type OneIndexSchema = {
 export type OneField = {
     crypt?: boolean,
     default?: string | number | boolean | object,
-    enum?: string[],
+    enum?: readonly string[],
     filter?: boolean,
     hidden?: boolean,
     map?: string,

--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -85,6 +85,9 @@ type OneTypedModel = Record<string, OneField>;
     Entity field signature generated from the schema
  */
 type EntityField<T extends OneField> =
+    T['enum'] extends readonly EntityFieldFromType<T>[] ? T['enum'][number] : EntityFieldFromType<T>;
+
+type EntityFieldFromType<T extends OneField> =
       T['type'] extends (ArrayConstructor | 'array') ? any[]
     : T['type'] extends (BooleanConstructor | 'boolean') ? boolean
     : T['type'] extends (NumberConstructor | 'number') ? number

--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -85,21 +85,13 @@ type OneTypedModel = Record<string, OneField>;
     Entity field signature generated from the schema
  */
 type EntityField<T extends OneField> =
-      T['type'] extends ArrayConstructor ? any[]
-    : T['type'] extends BooleanConstructor ? boolean
-    : T['type'] extends NumberConstructor ? number
-    : T['type'] extends ObjectConstructor ? object
-    : T['type'] extends DateConstructor ? Date
-    : T['type'] extends StringConstructor ? string
-    : T['type'] extends SetConstructor ? Set<T>
-
-    : T['type'] extends 'array' ? any[]
-    : T['type'] extends 'boolean' ? boolean
-    : T['type'] extends 'number' ? number
-    : T['type'] extends 'object' ? object
-    : T['type'] extends 'date' ? Date
-    : T['type'] extends 'string' ? string
-    : T['type'] extends 'set' ? Set<T>
+      T['type'] extends (ArrayConstructor | 'array') ? any[]
+    : T['type'] extends (BooleanConstructor | 'boolean') ? boolean
+    : T['type'] extends (NumberConstructor | 'number') ? number
+    : T['type'] extends (ObjectConstructor | 'object') ? object
+    : T['type'] extends (DateConstructor | 'date') ? Date
+    : T['type'] extends (StringConstructor | 'string') ? string
+    : T['type'] extends (SetConstructor | 'set') ? Set<T>
     : never;
 
 /*


### PR DESCRIPTION
In my local setup, the following code currently does not typecheck:
```typescript
import Dynamo from 'dynamodb-onetable/Dynamo'
import { Entity, Table } from 'dynamodb-onetable'
import { DynamoDBClient } from '@aws-sdk/client-dynamodb'

const client = new Dynamo({client: new DynamoDBClient({ apiVersion: '2012-08-10' })});

const schema = {
    version: '0.0.1',
    indexes: {
        primary: { hash: 'pk', sort: 'sk' },
        gs1:     { hash: 'gs1pk', sort: 'gs1sk', follow: true },
    },
    models: {
        User: {
            pk:          { type: String, value: 'account:${accountName}' },
            sk:          { type: String, value: 'user:${email}', validate: /.*@.*/ },
            id:          { type: String, required: true },
            email:       { type: String, required: true },
            role:        { type: String, enum: ['user', 'admin'], required: true, default: 'user' },

            gs1pk:       { type: String, value: 'user-email:${email}' },
            gs1sk:       { type: String, value: 'user:' },
        }
    } as const
};

const table = new Table({
    client,
    name: 'MyTable',
    schema,
});

type UserType = Entity<typeof schema.models.User>;

const User = table.getModel<UserType>('User');
```

It gives the following errors:
```
file.ts:30:5 - error TS2322: Type '{ version: string; indexes: { primary: { hash: string; sort: string; }; gs1: { hash: string; sort: string; follow: boolean; }; }; models: { readonly User: { readonly pk: { readonly type: StringConstructor; readonly value: "account:${accountName}"; }; ... 5 more ...; readonly gs1sk: { ...; }; }; }; }' is not assignable to type 'OneSchema'.
  Types of property 'models' are incompatible.
    Type '{ readonly User: { readonly pk: { readonly type: StringConstructor; readonly value: "account:${accountName}"; }; readonly sk: { readonly type: StringConstructor; readonly value: "user:${email}"; readonly validate: RegExp; }; ... 4 more ...; readonly gs1sk: { ...; }; }; }' is not assignable to type '{ [key: string]: OneModelSchema; }'.
      Property 'User' is incompatible with index signature.
        Type '{ readonly pk: { readonly type: StringConstructor; readonly value: "account:${accountName}"; }; readonly sk: { readonly type: StringConstructor; readonly value: "user:${email}"; readonly validate: RegExp; }; ... 4 more ...; readonly gs1sk: { ...; }; }' is not assignable to type 'OneModelSchema'.
          Property 'role' is incompatible with index signature.
            Type '{ readonly type: StringConstructor; readonly enum: readonly ["user", "admin"]; readonly required: true; readonly default: "user"; }' is not assignable to type 'OneField'.
              Types of property 'enum' are incompatible.
                The type 'readonly ["user", "admin"]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.

30     schema,
       ~~~~~~

  node_modules/dynamodb-onetable/dist/mjs/Table.d.ts:27:5
    27     schema?: OneSchema,             //  Table models schema.
           ~~~~~~
    The expected type comes from property 'schema' which is declared here on type 'TableConstructorParams'

file.ts:33:24 - error TS2344: Type '{ readonly pk: { readonly type: StringConstructor; readonly value: "account:${accountName}"; }; readonly sk: { readonly type: StringConstructor; readonly value: "user:${email}"; readonly validate: RegExp; }; ... 4 more ...; readonly gs1sk: { ...; }; }' does not satisfy the constraint 'OneTypedModel'.
  Property 'role' is incompatible with index signature.
    Type '{ readonly type: StringConstructor; readonly enum: readonly ["user", "admin"]; readonly required: true; readonly default: "user"; }' is not assignable to type 'OneField'.

33 type UserType = Entity<typeof schema.models.User>;
   
```

The errors occur because the `enum` property of the `OneField` type does not support `readonly` arrays. This pull request fixes this issue. Additionally the `EntityField` type is modified to only allow the specified values if the `enum` property exists.
