### PR TITLE
fix: timestamps + exists: null causes set to be overwritten

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -811,7 +811,10 @@ export class Model {
             if (params.exists == null) {
                 let field = this.block.fields[this.createdField] || this.table
                 let when = (field.isoDates) ? now.toISOString() : now.getTime()
-                params.set = { [this.createdField]: `if_not_exists(\${${this.createdField}}, {${when}})` }
+                params.set = {
+                    ...params.set,
+                    [this.createdField]: `if_not_exists(\${${this.createdField}}, {${when}})`
+                }
             }
         }
         properties = this.prepareProperties('update', properties, params)

--- a/src/Model.js
+++ b/src/Model.js
@@ -811,10 +811,8 @@ export class Model {
             if (params.exists == null) {
                 let field = this.block.fields[this.createdField] || this.table
                 let when = (field.isoDates) ? now.toISOString() : now.getTime()
-                params.set = {
-                    ...params.set,
-                    [this.createdField]: `if_not_exists(\${${this.createdField}}, {${when}})`
-                }
+                params.set = params.set || {}
+                params.set[this.createdField] = `if_not_exists(\${${this.createdField}}, {${when}})`
             }
         }
         properties = this.prepareProperties('update', properties, params)

--- a/test/timestamps.ts
+++ b/test/timestamps.ts
@@ -1,0 +1,63 @@
+/*
+    timestamps.ts - Basic operations with timestamps
+ */
+import { Client, Table } from './utils/init';
+
+const table = new Table({
+    name: 'TimestampsTable',
+    client: Client,
+    schema: {
+        version: '0.0.1',
+        indexes: {
+            primary: { hash: 'pk', sort: 'sk' },
+        },
+        models: {
+            User: {
+                pk:    { type: String, value: '${_type}#${id}' },
+                sk:    { type: String, value: '${_type}#' },
+                id:    { type: String, generate: 'ulid' },
+                name:  { type: String },
+                email: { type: String },
+            }
+        },
+        params: {
+            timestamps: true,
+            createdField: 'createdAt',
+            updatedField: 'updatedAt',
+        },
+    },
+})
+
+let User = null
+let user: any
+
+test('Create Table', async() => {
+    if (!(await table.exists())) {
+        await table.createTable()
+        expect(await table.exists()).toBe(true)
+    }
+    User = table.getModel('User')
+})
+
+test('Creates record with timestamps', async() => {
+    let properties = {
+        name: 'Peter Smith',
+        email: 'peter@example.com',
+    }
+    user = await User.create(properties)
+    expect(user.createdAt).toBeDefined()
+    expect(user.updatedAt).toBeDefined()
+})
+
+test('Updates using set and exists: null should not be overwritten by timestamps set', async() => {
+    const { id, createdAt, updatedAt } = user;
+    user = await User.update({ id }, { exists: null, set: { name: 'Marcelo' }})
+    expect(user.name).toEqual('Marcelo')
+    expect(user.createdAt).toEqual(createdAt)
+    expect(user.updatedAt.getTime()).toBeGreaterThan(updatedAt.getTime())
+})
+
+test('Destroy Table', async() => {
+    await table.deleteTable('DeleteTableForever')
+    expect(await table.exists()).toBe(false)
+})


### PR DESCRIPTION
When `timestamps: true` running an update with `set` and  `exists: null` causes the `set` values to be overwritten by the set of created at property.

![image](https://user-images.githubusercontent.com/980905/149830768-1f679173-813b-4572-bce8-fe095810590f.png)
