### PR TITLE
Correct and Adjust a syntax error in Javascript example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1411,8 +1411,8 @@ await User.update({id: userId}, {delete: {tokens: ['captain']}})
 await User.update({id: userId}, {remove: ['special', 'suspended']})
 await User.update({id: userId}, {set: {balance: '${balance} + {100}'}})
 await User.update({id: userId}, {
-    set: {contacts: 'list_append(${contacts} + @{newContacts}'},
-    substitutions: {newContacts: ['+15555555555']}
+    set: {contacts: 'list_append(if_not_exists(${contacts}, @{empty_list}), @{newContacts})'},
+    substitutions: {newContacts: ['+15555555555'], empty_list: []}
 })
 ```
 


### PR DESCRIPTION
The provided example in the README shows how to apply a ```list_append``` into ```update.set``` operation. The old example incorrectly uses the ```+``` between arguments. That needed replacement with a ```,```. 

Furthermore we adjusted the example with a ```if_not_exists``` helper to be able to set the initial contact.