### PR TITLE
feat: DataLoader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
+    - run: npm lint
     - run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm lint
     - run: npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
     globalSetup: '<rootDir>/test/utils/setup.ts',
     globalTeardown: '<rootDir>/test/utils/teardown.ts',
     testEnvironment: "node",
+    resetMocks: true,
     transform: {
         '^.+\\.(js|ts)$': 'ts-jest'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@types/jest": "^26.0.19",
                 "@types/node": "^14.14.16",
                 "aws-sdk": "^2.718.0",
+                "dataloader": "^2.0.0",
                 "dynamo-db-local": "^4.0.2",
                 "eslint": "^7.25.0",
                 "jest": "^26.6.3",
@@ -2851,6 +2852,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/dataloader": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+            "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+            "dev": true
         },
         "node_modules/debug": {
             "version": "4.3.2",
@@ -10123,6 +10130,12 @@
                 "whatwg-mimetype": "^2.3.0",
                 "whatwg-url": "^8.0.0"
             }
+        },
+        "dataloader": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+            "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==",
+            "dev": true
         },
         "debug": {
             "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "aws-sdk": "^2.718.0",
         "@types/jest": "^26.0.19",
         "@types/node": "^14.14.16",
+        "dataloader": "^2.0.0",
         "dynamo-db-local": "^4.0.2",
         "eslint": "^7.25.0",
         "jest": "^26.6.3",

--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -246,6 +246,7 @@ export type AnyModel = {
     create(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
     find(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     get(properties: OneProperties, params?: OneParams): Promise<AnyEntity | undefined>;
+    load(properties: OneProperties, params?: OneParams): Promise<AnyEntity | undefined>;
     init(properties?: OneProperties, params?: OneParams): AnyEntity;
     remove(properties: OneProperties, params?: OneParams): Promise<void>;
     scan(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
@@ -257,6 +258,7 @@ export class Model<T> {
     create(properties: EntityParameters<T>, params?: OneParams): Promise<T>;
     find(properties?: EntityParametersForFind<T>, params?: OneParams): Promise<Paged<T>>;
     get(properties: EntityParameters<T>, params?: OneParams): Promise<T | undefined>;
+    load(properties: EntityParameters<T>, params?: OneParams): Promise<T | undefined>;
     init(properties?: EntityParameters<T>, params?: OneParams): T;
     remove(properties: EntityParameters<T>, params?: OneParams): Promise<void>;
     scan(properties?: EntityParameters<T>, params?: OneParams): Promise<Paged<T>>;

--- a/src/Model.js
+++ b/src/Model.js
@@ -569,7 +569,7 @@ export class Model {
         ({properties, params} = this.checkArgs(properties, params))
         properties = this.prepareProperties('get', properties, params)
         let expression = new Expression(this, 'get', properties, params)
-        return await this.table.batchLoad(this, properties, params, expression)
+        return await this.table.batchLoad(expression)
     }
 
     init(properties = {}, params = {}) {

--- a/src/Model.js
+++ b/src/Model.js
@@ -565,6 +565,13 @@ export class Model {
         return await this.run('get', expression)
     }
 
+    async load(properties = {}, params = {}) {
+        ({properties, params} = this.checkArgs(properties, params))
+        properties = this.prepareProperties('get', properties, params)
+        let expression = new Expression(this, 'get', properties, params)
+        return await this.table.batchLoad(this, properties, params, expression)
+    }
+
     init(properties = {}, params = {}) {
         ({properties, params} = this.checkArgs(properties, params, {parse: true, high: true}))
         return this.initItem(properties, params)

--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -27,6 +27,9 @@ type TableConstructorParams = {
     //  Compute a value for a value template
     value?: (model: AnyModel, fieldName: string, properties: OneProperties, params?: OneParams) => string,
 
+    // https://www.npmjs.com/package/dataloader DataLoader constructor
+    dataloader?: new (batchLoadFn: any, options?: any) => any
+
     //  DEPRECATED 2.3 - Should now be specified via the schema.params
     createdField?: string,          //  Name of "created" timestamp attribute.
     hidden?: boolean,               //  Hide key attributes in Javascript properties. Default false.
@@ -89,6 +92,7 @@ export class Table {
     create(modelName: string, properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
     find(modelName: string, properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     get(modelName: string, properties: OneProperties, params?: OneParams): Promise<AnyEntity | undefined>;
+    load(modelName: string, properties: OneProperties, params?: OneParams): Promise<AnyEntity | undefined>;
     init(modelName: string, properties?: OneProperties, params?: OneParams): AnyEntity;
     remove(modelName: string, properties: OneProperties, params?: OneParams): Promise<void>;
     scan(modelName: string, properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;

--- a/src/Table.js
+++ b/src/Table.js
@@ -652,9 +652,9 @@ export class Table {
         return true
     }
 
-    async batchLoad(model, properties, params, expression) {
+    async batchLoad(expression) {
         if (this.dataloader) {
-            return await this.dataloader.load({ model, properties, params, expression })
+            return await this.dataloader.load(expression)
         }
         throw new Error('params.dataloader DataLoader constructor is required to use load feature')
     }
@@ -738,16 +738,16 @@ export class Table {
     }
 
     /**
-     * this is a function passed to the DataLoader that given an array of { model, properties, params, expression }
+     * this is a function passed to the DataLoader that given an array of Expression
      * will group all commands by TableName and make all Keys unique and then will perform
      * a BatchGet request and process the response of the BatchRequest to return an array
      * with the corresponding response in the same order as it was requested.
      *
-     * @param batch
+     * @param expressions
      * @returns {Promise<*>}
      */
-    async batchLoaderFunction(batch) {
-        const commands = batch.map(each => each.expression.command())
+    async batchLoaderFunction(expressions) {
+        const commands = expressions.map(each => each.command())
 
         const groupedByTableName =  commands.reduce((groupedBy, item) => {
             const tableName = item.TableName
@@ -779,7 +779,7 @@ export class Table {
         // return the exact mapping (on same order as input) of each get command request to the result from database
         // to do that we need to find in the Responses object the item that was request and return it in the same position
         return commands.map((command, index) => {
-            const { model, params } = batch[index]
+            const { model, params } = expressions[index]
 
             // each key is { pk: { S: "XX" } }
             // on map function, key will be pk and unmarshalled will be { S: "XX" }

--- a/src/Table.js
+++ b/src/Table.js
@@ -53,6 +53,8 @@ const DynamoOps = {
 
 const GenericModel = '_Generic'
 
+const maxBatchSize = 25
+
 /*
     Represent a single DynamoDB table
  */
@@ -81,6 +83,9 @@ export class Table {
         }
         this.setParams(params)
         this.schema = new Schema(this, params.schema)
+        if (params.dataloader) {
+            this.dataloader = new params.dataloader(cmds => this.batchLoaderFunction(cmds), { maxBatchSize })
+        }
     }
 
     setClient(client) {
@@ -497,6 +502,11 @@ export class Table {
         return await model.get(properties, params)
     }
 
+    async load(modelName, properties, params) {
+        let model = this.getModel(modelName)
+        return await model.load(properties, params)
+    }
+
     init(modelName, properties, params) {
         let model = this.getModel(modelName)
         return model.init(properties, params)
@@ -642,6 +652,13 @@ export class Table {
         return true
     }
 
+    async batchLoad(model, properties, params, expression) {
+        if (this.dataloader) {
+            return await this.dataloader.load({ model, properties, params, expression })
+        }
+        throw new Error('params.dataloader DataLoader constructor is required to use load feature')
+    }
+
     async deleteItem(properties, params) {
         return await this.schema.genericModel.deleteItem(properties, params)
     }
@@ -718,6 +735,73 @@ export class Table {
             list.push(preparedItem)
         }
         return result
+    }
+
+    /**
+     * this is a function passed to the DataLoader that given an array of { model, properties, params, expression }
+     * will group all commands by TableName and make all Keys unique and then will perform
+     * a BatchGet request and process the response of the BatchRequest to return an array
+     * with the corresponding response in the same order as it was requested.
+     *
+     * @param batch
+     * @returns {Promise<*>}
+     */
+    async batchLoaderFunction(batch) {
+        const commands = batch.map(each => each.expression.command())
+
+        const groupedByTableName =  commands.reduce((groupedBy, item) => {
+            const tableName = item.TableName
+            if (!groupedBy[tableName]) groupedBy[tableName] = []
+            groupedBy[tableName].push(item)
+            return groupedBy
+        }, {})
+
+        // convert each of the get requests into a single RequestItem with unique Keys
+        const requestItems = Object.keys(groupedByTableName).reduce((requestItems, tableName) => {
+            // batch get does not support duplicate Keys, so we need to make them unique
+            // it's complex because we have the unmarshalled values on the Keys
+            const allKeys = groupedByTableName[tableName].map(each => each.Key)
+            const uniqueKeys = allKeys.filter((key1, index1, self) => {
+                const index2 = self.findIndex(key2 => {
+                    return Object.keys(key2).every(prop => {
+                        const type = Object.keys(key1[prop])[0] // { S: "XX" } => type is S
+                        return key2[prop][type] === key1[prop][type]
+                    })
+                })
+                return index2 === index1
+            })
+            requestItems[tableName] = { Keys: uniqueKeys }
+            return requestItems
+        }, {})
+
+        const results = await this.batchGet({ RequestItems: requestItems })
+
+        // return the exact mapping (on same order as input) of each get command request to the result from database
+        // to do that we need to find in the Responses object the item that was request and return it in the same position
+        return commands.map((command, index) => {
+            const { model, params } = batch[index]
+
+            // each key is { pk: { S: "XX" } }
+            // on map function, key will be pk and unmarshalled will be { S: "XX" }
+            const criteria = Object.entries(command.Key).map(([key, unmarshalled]) => {
+                const type = Object.keys(unmarshalled)[0] // the type will be S
+                return [[key, type], unmarshalled[type]] // return [[pk, S], "XX"]
+            })
+
+            // finds the matching object in the unmarshalled Responses array with criteria Key above
+            const findByKeyUnmarshalled = (items = []) => items.find(item => {
+                return criteria.every(([[prop, type], value]) => {
+                    return item[prop][type] === value
+                })
+            })
+
+            const items = results.Responses[command.TableName]
+            const item = findByKeyUnmarshalled(items)
+            if (item) {
+                const unmarshalled = this.unmarshall(item, params)
+                return model.transformReadItem('get', unmarshalled, {}, params)
+            }
+        })
     }
 
     /*

--- a/test/loader.ts
+++ b/test/loader.ts
@@ -1,0 +1,85 @@
+/*
+   Batch loader
+ */
+
+// @ts-ignore
+import DataLoader from 'dataloader';
+import { DefaultSchema } from './schemas';
+import { Client, dynamoExecutedCommandsTracer, Table } from './utils/init';
+
+const table = new Table({
+  name: 'BatchTest',
+  client: Client,
+  schema: DefaultSchema,
+  dataloader: DataLoader
+});
+
+let users: any[];
+
+let data = [
+  { name: 'Peter Smith', email: 'peter@example.com', status: 'active' },
+  { name: 'Patty O\'Furniture', email: 'patty@example.com', status: 'active' },
+  { name: 'Cu Later', email: 'cu@example.com', status: 'inactive' }
+];
+
+describe('Loader', () => {
+  test('Create', async () => {
+    if (!(await table.exists())) {
+      await table.createTable();
+    }
+  });
+
+  test('Seed data', async () => {
+    const batch = {};
+    for (let item of data) {
+      await table.create('User', item, { batch });
+    }
+    await table.batchWrite(batch);
+    users = await table.scan('User');
+  });
+
+  test('Batch load', async () => {
+    // this will accumulate all gets request into a single batch request
+    const items = await Promise.all(
+      users.map(user => {
+        return table.load('User', { id: user.id });
+      })
+    );
+
+    expect(dynamoExecutedCommandsTracer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'BatchGetItemCommand'
+      })
+    );
+    expect(items.length).toBe(data.length);
+
+    for (let item of items) {
+      let datum = data.find(i => i.name == item.name);
+      expect(item).toMatchObject(datum);
+    }
+  });
+
+  test('Batch load (duplicate keys on batch get)', async () => {
+    // this will perform a single batch get operation with just one item get, and will return to each get the same value
+    const items = await Promise.all([
+      table.load('User', { id: users[0].id }),
+      table.load('User', { id: users[0].id }),
+      table.load('User', { id: users[0].id })
+    ]);
+
+    expect(dynamoExecutedCommandsTracer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'BatchGetItemCommand'
+      })
+    );
+
+    expect(items.length).toBe(3);
+    expect(items[0]).toEqual(users[0]);
+    expect(items[1]).toEqual(users[0]);
+    expect(items[2]).toEqual(users[0]);
+  });
+
+  test('Destroy', async () => {
+    await table.deleteTable('DeleteTableForever');
+  });
+});

--- a/test/loader.ts
+++ b/test/loader.ts
@@ -4,82 +4,82 @@
 
 // @ts-ignore
 import DataLoader from 'dataloader';
-import { DefaultSchema } from './schemas';
-import { Client, dynamoExecutedCommandsTracer, Table } from './utils/init';
+import {DefaultSchema} from './schemas';
+import {Client, dynamoExecutedCommandsTracer, Table} from './utils/init';
 
 const table = new Table({
-  name: 'BatchTest',
-  client: Client,
-  schema: DefaultSchema,
-  dataloader: DataLoader
+    name: 'BatchTest',
+    client: Client,
+    schema: DefaultSchema,
+    dataloader: DataLoader
 });
 
 let users: any[];
 
 let data = [
-  { name: 'Peter Smith', email: 'peter@example.com', status: 'active' },
-  { name: 'Patty O\'Furniture', email: 'patty@example.com', status: 'active' },
-  { name: 'Cu Later', email: 'cu@example.com', status: 'inactive' }
+    {name: 'Peter Smith', email: 'peter@example.com', status: 'active'},
+    {name: 'Patty O\'Furniture', email: 'patty@example.com', status: 'active'},
+    {name: 'Cu Later', email: 'cu@example.com', status: 'inactive'}
 ];
 
 describe('Loader', () => {
-  test('Create', async () => {
-    if (!(await table.exists())) {
-      await table.createTable();
-    }
-  });
+    test('Create', async () => {
+        if (!(await table.exists())) {
+            await table.createTable();
+        }
+    });
 
-  test('Seed data', async () => {
-    const batch = {};
-    for (let item of data) {
-      await table.create('User', item, { batch });
-    }
-    await table.batchWrite(batch);
-    users = await table.scan('User');
-  });
+    test('Seed data', async () => {
+        const batch = {};
+        for (let item of data) {
+            await table.create('User', item, {batch});
+        }
+        await table.batchWrite(batch);
+        users = await table.scan('User');
+    });
 
-  test('Batch load', async () => {
-    // this will accumulate all gets request into a single batch request
-    const items = await Promise.all(
-      users.map(user => {
-        return table.load('User', { id: user.id });
-      })
-    );
+    test('Batch load', async () => {
+        // this will accumulate all gets request into a single batch request
+        const items = await Promise.all(
+            users.map(user => {
+                return table.load('User', {id: user.id});
+            })
+        );
 
-    expect(dynamoExecutedCommandsTracer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        commandName: 'BatchGetItemCommand'
-      })
-    );
-    expect(items.length).toBe(data.length);
+        expect(dynamoExecutedCommandsTracer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                commandName: 'BatchGetItemCommand'
+            })
+        );
+        expect(items.length).toBe(data.length);
 
-    for (let item of items) {
-      let datum = data.find(i => i.name == item.name);
-      expect(item).toMatchObject(datum);
-    }
-  });
+        for (let item of items) {
+            let datum = data.find(i => i.name == item.name);
+            expect(item).toMatchObject(datum);
+        }
+    });
 
-  test('Batch load (duplicate keys on batch get)', async () => {
-    // this will perform a single batch get operation with just one item get, and will return to each get the same value
-    const items = await Promise.all([
-      table.load('User', { id: users[0].id }),
-      table.load('User', { id: users[0].id }),
-      table.load('User', { id: users[0].id })
-    ]);
+    test('Batch load (duplicate keys on batch get)', async () => {
+        // this will perform a single batch get operation with just one item get, and will return to each get the same value
+        const items = await Promise.all([
+            table.load('User', {id: users[0].id}),
+            table.load('User', {id: users[0].id}),
+            table.load('User', {id: users[0].id})
+        ]);
 
-    expect(dynamoExecutedCommandsTracer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        commandName: 'BatchGetItemCommand'
-      })
-    );
+        expect(dynamoExecutedCommandsTracer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                commandName: 'BatchGetItemCommand'
+            })
+        );
 
-    expect(items.length).toBe(3);
-    expect(items[0]).toEqual(users[0]);
-    expect(items[1]).toEqual(users[0]);
-    expect(items[2]).toEqual(users[0]);
-  });
+        expect(items.length).toBe(3);
+        expect(items[0]).toEqual(users[0]);
+        expect(items[1]).toEqual(users[0]);
+        expect(items[2]).toEqual(users[0]);
+    });
 
-  test('Destroy', async () => {
-    await table.deleteTable('DeleteTableForever');
-  });
+    test('Destroy', async () => {
+        await table.deleteTable('DeleteTableForever');
+    });
 });

--- a/test/utils/init.ts
+++ b/test/utils/init.ts
@@ -5,6 +5,8 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 
 const PORT = parseInt(process.env.DYNAMODB_PORT)
 
+const dynamoExecutedCommandsTracer = jest.fn()
+
 const Client = new Dynamo({
     client: new DynamoDBClient({
         endpoint: `http://localhost:${PORT}`,
@@ -13,6 +15,12 @@ const Client = new Dynamo({
             accessKeyId: 'test',
             secretAccessKey: 'test',
         }),
+        logger: {
+            debug: dynamoExecutedCommandsTracer,
+            info: dynamoExecutedCommandsTracer,
+            warn: dynamoExecutedCommandsTracer,
+            error: dynamoExecutedCommandsTracer
+        }
     })
 })
 
@@ -51,4 +59,4 @@ const Match = {
     phone:  /^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*$/,
 }
 
-export {AWS, Client, Dynamo, Entity, Match, Model, Table, delay, dump, print}
+export {AWS, Client, Dynamo, Entity, Match, Model, Table, delay, dump, print, dynamoExecutedCommandsTracer}


### PR DESCRIPTION
Original discussion https://github.com/sensedeep/dynamodb-onetable/discussions/250

In this PR I added the possibility to use https://www.npmjs.com/package/dataloader which allows to group all get requests made in parallel and perform a single BatchGetRequest.

For example (see tests for more) 

```js
// this will accumulate all gets request into a single batch request
// and return an array of items
const items = await Promise.all(
    ids.map(id => model.load({ id })
);
```

```js
// this will perform a single batch get operation with just one item get and will return to each get the same value
// dynamo does not supports duplicate keys on batch request and the implementation will deal with that
const items = await Promise.all([
  model.load({ id: 'same-id' }),
  model.load({ id: 'same-id' }),
  model.load({ id: 'same-id' })
]);
```

it solves this discussion https://github.com/sensedeep/dynamodb-onetable/discussions/235
```js
// this will perform 2 batch requests one with 25 items and another with the extra 5
// as DataLoader is configured with maxBatchSize = 25
// dynamo has a limit of 25 items on batch request
const items = await Promise.all([
  model.load({ id: '1' }),
  model.load({ id: '2' }),
  ...
  model.load({ id: '30' })
]);
```

With this implementation `batchGet` kind of gets deprecated as all `load` request will already be grouped and turned into `batchRequest` internally, if later we change the `batch` param on `get` to boolean and use internally the `load` method when it's true.

For example:

```js
async get(properties = {}, params = {}) {
    if (params.batch) {
        return await this.load(properties, params)
    }
    // do regular get
 }
```

That would be a great value to not have to use batch object and call batchGet manually.
