### PR TITLE
fix Set type

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -107,7 +107,7 @@ type EntityFieldFromType<T extends OneField> =
     : T['type'] extends (ObjectConstructor | 'object') ? object
     : T['type'] extends (DateConstructor | 'date') ? Date
     : T['type'] extends (StringConstructor | 'string') ? string
-    : T['type'] extends (SetConstructor | 'set') ? Set<T>
+    : T['type'] extends (SetConstructor | 'set') ? Set<any>
     : never;
 
 /*


### PR DESCRIPTION
for this schema 

```
const ReactionsSchema = {
  fields: {
    likes: { type: Set },
    dislikes: { type: Set },
  }
}
```

when doing 

 ```
 type Reactions = Entity<typeof ReactionsSchema.fields>;
```

the type of `Reactions.like` and `Reactions.dislikes` are resolved as `Set<{ type: Set }>`