### PR TITLE
fix: dataloader keys manipulation logic when v2 vs v3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,8 @@ module.exports = {
         "quotes": [ "error", "single", { "allowTemplateLiterals": true } ],
         "semi": [ "error", "never" ],
         "no-case-declarations": "off",
-        "indent": [ "error", 4, { "SwitchCase": 0, "flatTernaryExpressions": true } ]
+        "indent": [ "error", 4, { "SwitchCase": 0, "flatTernaryExpressions": true } ],
+        "object-curly-spacing": ["error", "never"]
     },
     "globals": {
         "expect": true,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,7 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm run lint --if-present
-    - run: npm test
+    - name: DynamoDB Client v2 Tests
+      run: DDB_CLIENT_VERSION=v2 npm test
+    - name: DynamoDB Client v3 Tests
+      run: DDB_CLIENT_VERSION=v3 npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
     - run: npm run build --if-present
     - run: npm run lint --if-present
     - name: DynamoDB Client v2 Tests
-      run: DDB_CLIENT_VERSION=v2 npm test
+      run: npm run test:v2
     - name: DynamoDB Client v3 Tests
-      run: DDB_CLIENT_VERSION=v3 npm test
+      run: npm run test:v3

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
         "prepare": "npm run build",
         "_prepublishOnly": "npm test && npm run lint",
         "test": "jest",
+        "test:v2": "DDB_CLIENT_VERSION=v2 jest",
+        "test:v3": "DDB_CLIENT_VERSION=v3 jest",
         "test-cov": "jest --coverage"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "scripts": {
         "build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup",
         "lint": "eslint src",
+        "lint-fix": "eslint src --fix",
         "prepare": "npm run build",
         "_prepublishOnly": "npm test && npm run lint",
         "test": "jest",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
         "test": "jest",
         "test:v2": "DDB_CLIENT_VERSION=v2 jest",
         "test:v3": "DDB_CLIENT_VERSION=v3 jest",
-        "test-cov": "jest --coverage"
+        "test-cov": "jest --coverage",
+        "test-cov:v2": "npm run test:v2 -- --coverage",
+        "test-cov:v3": "npm run test:v3 -- --coverage"
     },
     "repository": {
         "type": "git",

--- a/src/Expression.js
+++ b/src/Expression.js
@@ -456,11 +456,11 @@ export class Expression {
         let args
         if (params.batch) {
             if (op == 'get') {
-                args = { Keys: key }
+                args = {Keys: key}
             } else if (op == 'delete') {
-                args = { Key: key }
+                args = {Key: key}
             } else if (op == 'put') {
-                args = { Item: puts }
+                args = {Item: puts}
             } else {
                 throw new OneTableArgError(`Unsupported batch operation "${op}"`)
             }

--- a/src/Metrics.js
+++ b/src/Metrics.js
@@ -149,7 +149,7 @@ export class Metrics {
 
     addMetric(key, values, dimensions, dimensionValues, properties) {
         let rec = this.metrics.counters[key] = this.metrics.counters[key] || {
-            totals: { count: 0, latency: 0, read: 0, requests: 0, scanned: 0, write: 0 },
+            totals: {count: 0, latency: 0, read: 0, requests: 0, scanned: 0, write: 0},
             dimensions: dimensions.slice(0),
             dimensionValues,
             properties,

--- a/src/Model.js
+++ b/src/Model.js
@@ -27,9 +27,9 @@ const TransformParseResponseAs = {
     update: 'get'
 }
 
-const KeysOnly = { delete: true, get: true }
-const TransactOps = { delete: 'Delete', get: 'Get', put: 'Put', update: 'Update' }
-const BatchOps = { delete: 'DeleteRequest', put: 'PutRequest', update: 'PutRequest' }
+const KeysOnly = {delete: true, get: true}
+const TransactOps = {delete: 'Delete', get: 'Get', put: 'Put', update: 'Update'}
+const BatchOps = {delete: 'DeleteRequest', put: 'PutRequest', update: 'PutRequest'}
 const ValidTypes = [ 'array', 'binary', 'boolean', 'buffer', 'date', 'number', 'object', 'set', 'string' ]
 const SanityPages = 1000
 const FollowThreads = 10
@@ -105,14 +105,14 @@ export class Model {
         if (!prefix) {
             //  Top level only
             if (!schemaFields[this.typeField]) {
-                schemaFields[this.typeField] = { type: String, hidden: true }
+                schemaFields[this.typeField] = {type: String, hidden: true}
                 if (!this.generic) {
                     schemaFields[this.typeField].required = true
                 }
             }
             if (this.timestamps) {
-                schemaFields[this.createdField] = schemaFields[this.createdField] || { type: Date }
-                schemaFields[this.updatedField] = schemaFields[this.updatedField] || { type: Date }
+                schemaFields[this.createdField] = schemaFields[this.createdField] || {type: Date}
+                schemaFields[this.updatedField] = schemaFields[this.updatedField] || {type: Date}
             }
         }
         let {indexes, table} = this
@@ -377,7 +377,7 @@ export class Model {
         let prev
         if ((op == 'find' || op == 'scan') && items.length) {
             let {hash, sort} = index
-            prev = { [hash]: items[0][hash], [sort]: items[0][sort]}
+            prev = {[hash]: items[0][hash], [sort]: items[0][sort]}
             if (prev[hash] == null || prev[sort] == null) {
                 prev = null
             }

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -157,17 +157,17 @@ export class Schema {
         let {indexes, table} = this
         let primary = indexes.primary
         let fields = this.schemaModelFields = {
-            [primary.hash]: { type: 'string', required: true, value: `${SchemaKey}` },
-            format:         { type: 'string', required: true },
-            indexes:        { type: 'object', required: true },
-            name:           { type: 'string', required: true },
-            models:         { type: 'object', required: true },
-            params:         { type: 'object', required: true },
-            queries:        { type: 'object', required: true },
-            version:        { type: 'string', required: true },
+            [primary.hash]: {type: 'string', required: true, value: `${SchemaKey}`},
+            format:         {type: 'string', required: true},
+            indexes:        {type: 'object', required: true},
+            name:           {type: 'string', required: true},
+            models:         {type: 'object', required: true},
+            params:         {type: 'object', required: true},
+            queries:        {type: 'object', required: true},
+            version:        {type: 'string', required: true},
         }
         if (primary.sort) {
-            fields[primary.sort] = { type: 'string', required: true, value: `${SchemaKey}:\${name}`}
+            fields[primary.sort] = {type: 'string', required: true, value: `${SchemaKey}:\${name}`}
         }
         this.models[SchemaModel] = new Model(table, SchemaModel, {fields})
     }
@@ -176,14 +176,14 @@ export class Schema {
         let {indexes} = this
         let primary = indexes.primary
         let fields = this.migrationModelFields = {
-            [primary.hash]: { type: 'string', value: `${MigrationKey}` },
-            date:           { type: 'date',   required: true },
-            description:    { type: 'string', required: true },
-            path:           { type: 'string', required: true },
-            version:        { type: 'string', required: true },
+            [primary.hash]: {type: 'string', value: `${MigrationKey}`},
+            date:           {type: 'date',   required: true},
+            description:    {type: 'string', required: true},
+            path:           {type: 'string', required: true},
+            version:        {type: 'string', required: true},
         }
         if (primary.sort) {
-            fields[primary.sort] = { type: 'string', value: `${MigrationKey}:\${version}` }
+            fields[primary.sort] = {type: 'string', value: `${MigrationKey}:\${version}`}
         }
         this.models[MigrationModel] = new Model(this.table, MigrationModel, {fields, indexes})
     }

--- a/src/Table.js
+++ b/src/Table.js
@@ -7,10 +7,10 @@
 import Crypto from 'crypto'
 import UUID from './UUID.js'
 import ULID from './ULID.js'
-import { Expression } from './Expression.js'
-import { Schema } from './Schema.js'
-import { Metrics } from './Metrics.js'
-import { OneTableArgError, OneTableError } from './Error.js'
+import {Expression} from './Expression.js'
+import {Schema} from './Schema.js'
+import {Metrics} from './Metrics.js'
+import {OneTableArgError, OneTableError} from './Error.js'
 
 /*
     AWS V2 DocumentClient methods
@@ -84,7 +84,7 @@ export class Table {
         this.setParams(params)
         this.schema = new Schema(this, params.schema)
         if (params.dataloader) {
-            this.dataloader = new params.dataloader(cmds => this.batchLoaderFunction(cmds), { maxBatchSize })
+            this.dataloader = new params.dataloader(cmds => this.batchLoaderFunction(cmds), {maxBatchSize})
         }
     }
 
@@ -774,16 +774,16 @@ export class Table {
                 })
                 return index2 === index1
             })
-            requestItems[tableName] = { Keys: uniqueKeys }
+            requestItems[tableName] = {Keys: uniqueKeys}
             return requestItems
         }, {})
 
-        const results = await this.batchGet({ RequestItems: requestItems })
+        const results = await this.batchGet({RequestItems: requestItems})
 
         // return the exact mapping (on same order as input) of each get command request to the result from database
         // to do that we need to find in the Responses object the item that was request and return it in the same position
         return commands.map((command, index) => {
-            const { model, params } = expressions[index]
+            const {model, params} = expressions[index]
 
             // each key is { pk: { S: "XX" } } when V3 or { pk: "XX" } when V2
             // on map function, key will be pk and unmarshalled will be { S: "XX" }, OR "XXX"

--- a/src/Table.js
+++ b/src/Table.js
@@ -7,10 +7,10 @@
 import Crypto from 'crypto'
 import UUID from './UUID.js'
 import ULID from './ULID.js'
-import {Expression} from './Expression.js'
-import {Schema} from './Schema.js'
-import {Metrics} from './Metrics.js'
-import {OneTableError, OneTableArgError} from './Error.js'
+import { Expression } from './Expression.js'
+import { Schema } from './Schema.js'
+import { Metrics } from './Metrics.js'
+import { OneTableArgError, OneTableError } from './Error.js'
 
 /*
     AWS V2 DocumentClient methods
@@ -760,13 +760,16 @@ export class Table {
         // convert each of the get requests into a single RequestItem with unique Keys
         const requestItems = Object.keys(groupedByTableName).reduce((requestItems, tableName) => {
             // batch get does not support duplicate Keys, so we need to make them unique
-            // it's complex because we have the unmarshalled values on the Keys
+            // it's complex because we have the unmarshalled values on the Keys when it's V3
             const allKeys = groupedByTableName[tableName].map(each => each.Key)
             const uniqueKeys = allKeys.filter((key1, index1, self) => {
                 const index2 = self.findIndex(key2 => {
                     return Object.keys(key2).every(prop => {
-                        const type = Object.keys(key1[prop])[0] // { S: "XX" } => type is S
-                        return key2[prop][type] === key1[prop][type]
+                        if (this.V3) {
+                            const type = Object.keys(key1[prop])[0] // { S: "XX" } => type is S
+                            return key2[prop][type] === key1[prop][type]
+                        }
+                        return key2[prop] === key1[prop]
                     })
                 })
                 return index2 === index1
@@ -782,17 +785,21 @@ export class Table {
         return commands.map((command, index) => {
             const { model, params } = expressions[index]
 
-            // each key is { pk: { S: "XX" } }
-            // on map function, key will be pk and unmarshalled will be { S: "XX" }
+            // each key is { pk: { S: "XX" } } when V3 or { pk: "XX" } when V2
+            // on map function, key will be pk and unmarshalled will be { S: "XX" }, OR "XXX"
             const criteria = Object.entries(command.Key).map(([key, unmarshalled]) => {
-                const type = Object.keys(unmarshalled)[0] // the type will be S
-                return [[key, type], unmarshalled[type]] // return [[pk, S], "XX"]
+                if (this.V3) {
+                    const type = Object.keys(unmarshalled)[0] // the type will be S
+                    return [[key, type], unmarshalled[type]] // return [[pk, S], "XX"]
+                }
+                return [[key], unmarshalled]
             })
 
             // finds the matching object in the unmarshalled Responses array with criteria Key above
             const findByKeyUnmarshalled = (items = []) => items.find(item => {
                 return criteria.every(([[prop, type], value]) => {
-                    return item[prop][type] === value
+                    if (type) return item[prop][type] === value // if it has a type it means it is V3
+                    return item[prop] === value
                 })
             })
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,11 @@
     dynamodb-onetable - DynamoDB wrapper for single table patterns
 */
 
-import { Expression } from './Expression.js'
-import { Model } from './Model.js'
-import { Table } from './Table.js'
-import { OneTableError, OneTableArgError } from './Error'
+import {Expression} from './Expression.js'
+import {Model} from './Model.js'
+import {Table} from './Table.js'
+import {OneTableError, OneTableArgError} from './Error'
 import ULID from './ULID.js'
 import UUID from './UUID.js'
 
-export { Expression, Model, OneTableArgError, OneTableError, Table, ULID, UUID }
+export {Expression, Model, OneTableArgError, OneTableError, Table, ULID, UUID}

--- a/test/batch.ts
+++ b/test/batch.ts
@@ -2,8 +2,8 @@
    Batch get/write
  */
 
-import {AWS, Client, Table, print, dump, delay} from './utils/init'
 import {DefaultSchema} from './schemas'
+import {Client, isV2, isV3, Table} from './utils/init'
 
 // jest.setTimeout(7200 * 1000)
 
@@ -83,7 +83,8 @@ test('Batch get without parse', async() => {
     }
     let response: any = await table.batchGet(batch, {hidden: false})
     expect(response.Responses).toBeDefined()
-    expect(response['$metadata']).toBeDefined()
+    if (isV3()) expect(response['$metadata']).toBeDefined()
+    if (isV2()) expect(response['$response']).toBeDefined()
 })
 
 test('Batch with error', async() => {

--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -1,7 +1,7 @@
 /*
     crypto.ts - CRUD with crypto
  */
-import {AWS, Client, Match, Table, print, dump, delay} from './utils/init'
+import {AWS, Client, Match, Table, print, dump, delay, isV3, isV2} from './utils/init'
 import {CryptoSchema} from './schemas'
 
 const Crypto = {
@@ -50,10 +50,18 @@ test('Get', async() => {
 
 test('Get raw ', async() => {
     user = await User.get({id: user.id}, {hidden: true, parse: false})
-    expect(user.pk.S).toMatch(/^User#/)
-    expect(user.email.S).toBeDefined()
-    expect(user.email.S).not.toMatch('peter@example.com')
-    expect(user.email.S).toMatch(/^primary/)
+    if (isV3()) {
+        expect(user.pk.S).toMatch(/^User#/)
+        expect(user.email.S).toBeDefined()
+        expect(user.email.S).not.toMatch('peter@example.com')
+        expect(user.email.S).toMatch(/^primary/)
+    }
+    if (isV2()) {
+        expect(user.pk).toMatch(/^User#/)
+        expect(user.email).toBeDefined()
+        expect(user.email).not.toMatch('peter@example.com')
+        expect(user.email).toMatch(/^primary/)
+    }
 })
 
 test('Destroy Table', async() => {

--- a/test/mapping-and-packing.ts
+++ b/test/mapping-and-packing.ts
@@ -4,7 +4,7 @@
     This tests simple mapping of properties to an abbreviated attribute and
     packing properties into a single attribute
  */
-import {AWS, Client, Match, Table, print, dump, delay} from './utils/init'
+import {AWS, Client, Match, Table, print, dump, delay, isV3, isV2} from './utils/init'
 import {MappedSchema} from './schemas'
 
 // jest.setTimeout(7200 * 1000)
@@ -72,12 +72,22 @@ test('Get including hidden', async() => {
 test('Get without parse', async() => {
     //  Returns attributes without parsing including hidden (pk, sk)
     let u = await User.get({id: user.id}, {hidden: true, parse: false})
-    expect(u.id.S).toMatch(Match.ulid)
-    expect(u.em.S).toEqual('peter@example.com')
-    expect(u.pk.S).toEqual(`us#${u.id.S}`)
-    expect(u.sk.S).toEqual(`us#`)
-    expect(u.pk1.S).toEqual(`ty#us`)
-    expect(u.sk1.S).toEqual(`us#${user.email}`)
+    if (isV3()) {
+        expect(u.id.S).toMatch(Match.ulid)
+        expect(u.em.S).toEqual('peter@example.com')
+        expect(u.pk.S).toEqual(`us#${u.id.S}`)
+        expect(u.sk.S).toEqual(`us#`)
+        expect(u.pk1.S).toEqual(`ty#us`)
+        expect(u.sk1.S).toEqual(`us#${user.email}`)
+    }
+    if (isV2()) {
+        expect(u.id).toMatch(Match.ulid)
+        expect(u.em).toEqual('peter@example.com')
+        expect(u.pk).toEqual(`us#${u.id}`)
+        expect(u.sk).toEqual(`us#`)
+        expect(u.pk1).toEqual(`ty#us`)
+        expect(u.sk1).toEqual(`us#${user.email}`)
+    }
 })
 
 test('Get via GSI', async() => {

--- a/test/unique.ts
+++ b/test/unique.ts
@@ -1,8 +1,8 @@
 /*
     unique.ts - Test unique crud
  */
-import {AWS, Client, Entity, Match, Model, Table, print, dump, delay} from './utils/init'
 import {UniqueSchema} from './schemas'
+import {Client, Entity, isV2, isV3, Model, Table} from './utils/init'
 
 // jest.setTimeout(7200 * 1000)
 
@@ -39,8 +39,16 @@ test('Create user 1', async() => {
     let items = await table.scanItems()
     expect(items.length).toBe(3)
 
-    let unique = items.filter((item) => item.pk.S.indexOf('interpolated') >= 0)
-    let pk = unique[0].pk.S
+    let pk = (() => {
+        if (isV3()) {
+            let unique = items.filter((item) => (item.pk.S).indexOf('interpolated') >= 0)
+            return unique[0].pk.S
+        }
+        if (isV2()) {
+            let unique = items.filter((item) => (item.pk).indexOf('interpolated') >= 0)
+            return unique[0].pk
+        }
+    })()
     expect(pk.indexOf('Peter Smith') >= 0).toBe(true)
     expect(pk.indexOf('peter@example.com') >= 0).toBe(true)
     expect(pk.indexOf('User') >= 0).toBe(true)

--- a/test/utils/init.ts
+++ b/test/utils/init.ts
@@ -1,8 +1,7 @@
-import AWS from 'aws-sdk'
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
+import AWS, {DynamoDB} from 'aws-sdk'
 import Dynamo from '../../src/Dynamo.js'
-import { Entity, Model, Table } from '../../src/index.js'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
-import { DynamoDB } from 'aws-sdk'
+import {Entity, Model, Table} from '../../src/index.js'
 
 const PORT = parseInt(process.env.DYNAMODB_PORT)
 


### PR DESCRIPTION
- fixed logic for dataloader keys manipulation when client v2 vs v3 (v3 has `{S:''}` and v2 is `''`)
- run all tests both with v2 and v3