### PR TITLE
fix module import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 import { Expression } from './Expression.js'
 import { Model } from './Model.js'
 import { Table } from './Table.js'
-import { OneTableError, OneTableArgError } from './Error'
+import { OneTableError, OneTableArgError } from './Error.js'
 import ULID from './ULID.js'
 import UUID from './UUID.js'
 


### PR DESCRIPTION
I ran into an issue when using OneTable in ESM setup:

```
/.../node_modules/ts-node/dist-raw/node-esm-resolve-implementation.js:383
    throw new ERR_MODULE_NOT_FOUND(
          ^
CustomError: Cannot find module '/.../node_modules/dynamodb-onetable/dist/mjs/Error' imported from /.../node_modules/dynamodb-onetable/dist/mjs/index.js
```