### PR TITLE
Handle error narrowing with aws-sdk v3

### DIFF
--- a/src/Error.js
+++ b/src/Error.js
@@ -22,8 +22,9 @@ function init(self, message, context) {
 
 export function checkErr(error, code) {
     // aws sdk v3 has moved code to name - see https://github.com/aws/aws-sdk-js-v3/issues/2874
-    return error.code == code || error.name == code; 
+    return error.code == code || error.name == code
 }
+
 export class OneTableError extends Error {
     constructor(message, context) {
         super(message)

--- a/src/Error.js
+++ b/src/Error.js
@@ -20,6 +20,10 @@ function init(self, message, context) {
     }
 }
 
+export function checkErr(error, code) {
+    // aws sdk v3 has moved code to name - see https://github.com/aws/aws-sdk-js-v3/issues/2874
+    return error.code == code || error.name == code; 
+}
 export class OneTableError extends Error {
     constructor(message, context) {
         super(message)

--- a/src/Model.js
+++ b/src/Model.js
@@ -4,7 +4,7 @@
     A model represents a DynamoDB single-table entity.
 */
 import {Expression} from './Expression.js'
-import {OneTableError, OneTableArgError} from './Error.js'
+import {OneTableError, OneTableArgError, checkErr} from './Error.js'
 
 /*
     Ready / write tags for interceptions
@@ -540,7 +540,7 @@ export class Model {
         try {
             await this.table.transact('write', params.transaction, params)
         } catch (err) {
-            if (err.message.indexOf('ConditionalCheckFailed') >= 0) {
+            if (checkErr(err, 'ConditionalCheckFailedException')) {
                 let names = fields.map(f => f.name).join(', ')
                 throw new OneTableError(
                     `Cannot create unqiue attributes "${names}" for "${this.name}", an item of the same name already exists.`,
@@ -738,7 +738,7 @@ export class Model {
             await this.table.transact('write', params.transaction, params)
 
         } catch (err) {
-            if (err.message.indexOf('ConditionalCheckFailed') >= 0) {
+            if (checkErr(err, 'ConditionalCheckFailedException')) {
                 let names = fields.map(f => f.name).join(', ')
                 throw new OneTableError(`Cannot update unqiue attributes "${names}" for "${this.name}", ` +
                                    `an item of the same name already exists.`, {properties, transaction, code: 'UniqueError'})

--- a/src/Table.js
+++ b/src/Table.js
@@ -10,7 +10,7 @@ import ULID from './ULID.js'
 import {Expression} from './Expression.js'
 import {Schema} from './Schema.js'
 import {Metrics} from './Metrics.js'
-import {OneTableArgError, OneTableError} from './Error.js'
+import {OneTableArgError, OneTableError, checkErr} from './Error.js'
 
 /*
     AWS V2 DocumentClient methods
@@ -549,12 +549,12 @@ export class Table {
             if (params.throw === false) {
                 result = {}
 
-            } else if (err.code == 'ConditionalCheckFailedException' && op == 'put') {
+            } else if (checkErr(err, 'ConditionalCheckFailedException') && op == 'put') {
                 //  Not a hard error -- typically part of normal operation
                 this.log.info(`Conditional check failed "${op}" on "${model}"`, {err, trace})
                 throw new OneTableError(`Conditional create failed for "${model}"`, {code: 'ConditionError', trace, err})
 
-            } else if (err.code == 'ProvisionedThroughputExceededException') {
+            } else if (checkErr(err, 'ProvisionedThroughputExceededException')) {
                 throw err
                 // FUTURE throw new OneTableError(`Provisioned throughput exceeded`, {code: 'ProvisionedThroughputExceededException', trace, err})
 

--- a/test/crud.ts
+++ b/test/crud.ts
@@ -78,6 +78,17 @@ test('Create', async() => {
     expect(user.registered.toString()).toBe(now.toString())
     expect(user.pk).toBeUndefined()
     expect(user.sk).toBeUndefined()
+
+    // try to create a duplicate
+    let newParams = {
+        id: user.id,
+        ...params,
+    }
+    try {
+        user = await User.create(newParams)
+    } catch (err) {
+        expect(err.code).toBe('ConditionError');
+    }
 })
 
 test('Get', async() => {


### PR DESCRIPTION
aws-sdk v3 seems to have changed where the error types are stored. Previously it was in .code. Now it is in .name. See https://github.com/aws/aws-sdk-js-v3/issues/2874

The consequence of that is that error narrowing no longer works. E.g. creating an item twice does not raise a neat ConditionError any more. It is a generic failure that is harder to handle.

This PR aims to resolve that issue while retaining compatibility with v2.