### PR TITLE
Add Table.child typescript definition

### DIFF
--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -89,6 +89,8 @@ export class Table {
     scanItems(properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     updateItem(properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
 
+    child(context: {}): Table;
+
     create(modelName: string, properties: OneProperties, params?: OneParams): Promise<AnyEntity>;
     find(modelName: string, properties?: OneProperties, params?: OneParams): Promise<Paged<AnyEntity>>;
     get(modelName: string, properties: OneProperties, params?: OneParams): Promise<AnyEntity | undefined>;


### PR DESCRIPTION
Table object has a very useful method `child` but typescript definition for it is missing.