### PR TITLE
Fix null property deref in OneTableArgError

### DIFF
--- a/src/Error.js
+++ b/src/Error.js
@@ -44,6 +44,6 @@ export class OneTableArgError extends Error {
     constructor(message, context) {
         super(message, context)
         init(this, message, context)
-        this.code = context.code || 'ArgumentError'
+        this.code = context?.code || 'ArgumentError'
     }
 }


### PR DESCRIPTION
`context` argument is allowed to be null or undefined by type definition, and many callers (e.g., Table.js)
use the `message`-only constructor, so the deref of `.code` needs to use the null/undef-safe operator `?.`

Discovered by feeding a "works with an older version" schema to the `Table` constructor and getting
```
TypeError: Cannot read property 'code' of undefined
    at new OneTableArgError
```