### PR TITLE
Add missing check for numeric value

### DIFF
--- a/src/Expression.js
+++ b/src/Expression.js
@@ -594,7 +594,7 @@ export class Expression {
         if (index == null) {
             index = this.vindex++
             this.values[`:_${index}`] = value
-            if (value && typeof value != 'object') {
+            if (value && typeof value != 'object' && typeof value != 'number') {
                 this.valuesMap[value] = index
             }
         }


### PR DESCRIPTION
The problem referenced in the comment:

> Except for numbers because we don't want to confuse valuesMap indexes. i.e. 7 vs "7" 

was still present if a number came first in the attribute list, i.e. `{"version": 1, "id": "1"}` - in this case you get id set to the number `1` instead of a string.