### PR TITLE
fix: Allow substitutions to be falsy

### DIFF
--- a/src/Expression.js
+++ b/src/Expression.js
@@ -232,7 +232,7 @@ export class Expression {
             let index
             const {substitutions} = this.params
             let name = value.replace(/^\.\.\./, '')
-            if (!substitutions || !substitutions[name]) {
+            if (!substitutions || substitutions[name] === undefined) {
                 throw new OneTableError(`Missing substitutions for attribute value "${name}"`, {
                     expr,
                     substitutions,


### PR DESCRIPTION
Missing substitutions was being thrown if the substitution was supplied but falsy. This is particularly problematic when filtering on a boolean value.