### PR TITLE
Support optional unique values.

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -545,10 +545,10 @@ export class Model {
         try {
             await this.table.transact('write', params.transaction, params)
         } catch (err) {
-            if (err.message.indexOf('ConditionalCheckFailed') >= 0) {
+            if (err instanceof OneTableError && err.code === 'TransactionCanceledException' && err.context.err.message.indexOf('ConditionalCheckFailed') !== -1) {
                 let names = fields.map(f => f.name).join(', ')
                 throw new OneTableError(
-                    `Cannot create unqiue attributes "${names}" for "${this.name}", an item of the same name already exists.`,
+                    `Cannot create unique attributes "${names}" for "${this.name}", an item of the same name already exists.`,
                     {properties, transaction, code: 'UniqueError'})
             }
             throw err
@@ -748,10 +748,13 @@ export class Model {
             await this.table.transact('write', params.transaction, params)
 
         } catch (err) {
-            if (err.message.indexOf('ConditionalCheckFailed') >= 0) {
+            console.log(err.code)
+            console.log(err.context.err)
+            if (err instanceof OneTableError && err.code === 'TransactionCanceledException' && err.context.err.message.indexOf('ConditionalCheckFailed') !== -1) {
                 let names = fields.map(f => f.name).join(', ')
-                throw new OneTableError(`Cannot update unqiue attributes "${names}" for "${this.name}", ` +
-                                   `an item of the same name already exists.`, {properties, transaction, code: 'UniqueError'})
+                throw new OneTableError(
+                    `Cannot update unique attributes "${names}" for "${this.name}", an item of the same name already exists.`,
+                    {properties, transaction, code: 'UniqueError'})
             }
             throw err
         }

--- a/test/schemas/uniqueSchema.ts
+++ b/test/schemas/uniqueSchema.ts
@@ -12,7 +12,8 @@ export default {
             pk:           { type: String, value: '${_type}#${name}' },
             sk:           { type: String, value: '${_type}#' },
             name:         { type: String },
-            email:        { type: String, unique: true },
+            email:        { type: String, unique: true, required: true },
+            phone:        { type: String, unique: true },
             age:          { type: Number },
             interpolated: { type: String, value: '${name}#${email}', unique: true },
         }

--- a/test/unique.ts
+++ b/test/unique.ts
@@ -3,6 +3,7 @@
  */
 import {UniqueSchema} from './schemas'
 import {Client, Entity, isV2, isV3, Model, Table} from './utils/init'
+import {OneTableError} from '../src';
 
 // jest.setTimeout(7200 * 1000)
 
@@ -112,7 +113,11 @@ test('Create non-unique email', async() => {
     }
     await expect(async () => {
         user = await User.create(props)
-    }).rejects.toThrow()
+    }).rejects.toThrow(new OneTableError(
+        `Cannot create unique attributes "email, interpolated" for "User", an item of the same name already exists.`,
+        {
+            code: 'UniqueError'
+        }))
 
     let items = await table.scanItems()
     expect(items.length).toBe(6)
@@ -125,7 +130,11 @@ test('Update non-unique email', async() => {
     }
     await expect(async () => {
         await User.update(props, {return: 'none'})
-    }).rejects.toThrow()
+    }).rejects.toThrow(new OneTableError(
+        `Cannot update unique attributes "email, interpolated" for "User", an item of the same name already exists.`,
+        {
+            code: 'UniqueError'
+        }))
 
     let items = await table.scanItems()
     expect(items.length).toBe(6)

--- a/test/unique.ts
+++ b/test/unique.ts
@@ -59,12 +59,25 @@ test('Create user 2', async() => {
     const props = {
         name: 'Judy Smith',
         email: 'judy@example.com',
+        phone: '+15555555555'
     }
     user = await User.create(props)
     expect(user).toMatchObject(props)
 
     let items = await table.scanItems()
-    expect(items.length).toBe(6)
+    expect(items.length).toBe(7)
+})
+
+test('Update user 2 with the same email', async() => {
+    const props = {
+        name: 'Judy Smith',
+        email: 'judy@example.com',
+    }
+    user = await User.update(props, {return: 'get'})
+    expect(user).toMatchObject(props)
+
+    let items = await table.scanItems()
+    expect(items.length).toBe(7)
 })
 
 test('Update user 2 with unique email', async() => {
@@ -76,9 +89,8 @@ test('Update user 2 with unique email', async() => {
     expect(user).toMatchObject(props)
 
     let items = await table.scanItems()
-    expect(items.length).toBe(6)
+    expect(items.length).toBe(7)
 })
-
 
 test('Update non-unique property', async() => {
     const props = {
@@ -89,7 +101,7 @@ test('Update non-unique property', async() => {
     expect(user).toMatchObject(props)
 
     let items = await table.scanItems()
-    expect(items.length).toBe(6)
+    expect(items.length).toBe(7)
 })
 
 test('Update with unknown property', async() => {
@@ -103,6 +115,20 @@ test('Update with unknown property', async() => {
     expect(user).toMatchObject(expectedProps)
 
     let items = await table.scanItems()
+    expect(items.length).toBe(7)
+})
+
+test('Update to remove optional unique property', async() => {
+    const props = {
+        name: 'Judy Smith',
+        phone: null
+    }
+    user = await User.update(props, {return: 'get', log:true})
+    const {phone, ...expectedProps} = props
+    expect(user).toMatchObject(expectedProps)
+    expect(user.phone).toBeUndefined()
+
+    let items = await table.scanItems()
     expect(items.length).toBe(6)
 })
 
@@ -114,7 +140,7 @@ test('Create non-unique email', async() => {
     await expect(async () => {
         user = await User.create(props)
     }).rejects.toThrow(new OneTableError(
-        `Cannot create unique attributes "email, interpolated" for "User", an item of the same name already exists.`,
+        `Cannot create unique attributes "email, phone, interpolated" for "User", an item of the same name already exists.`,
         {
             code: 'UniqueError'
         }))
@@ -131,7 +157,7 @@ test('Update non-unique email', async() => {
     await expect(async () => {
         await User.update(props, {return: 'none'})
     }).rejects.toThrow(new OneTableError(
-        `Cannot update unique attributes "email, interpolated" for "User", an item of the same name already exists.`,
+        `Cannot update unique attributes "email, phone, interpolated" for "User", an item of the same name already exists.`,
         {
             code: 'UniqueError'
         }))


### PR DESCRIPTION
This was discussed a while ago: https://github.com/sensedeep/dynamodb-onetable/discussions/195 and partially supported. However, while optional values were fine on create, then would fail on update and delete in some cases.

I've tried to cover all the error cases in tests, but it's a little tricky since the tests aren't truly independent.

Builds on https://github.com/sensedeep/dynamodb-onetable/pull/313