### PR TITLE
pass an array of strings for a `Set` field

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -1572,7 +1572,7 @@ export class Model {
         if (!Array.isArray(value)) {
             throw new OneTableError('Set values must be arrays', {code: 'TypeError'})
         }
-        if (type == Set || type == 'Set') {
+        if (type == Set || type == 'Set' || type == 'set') {
             let v = value.values().next().value
             if (typeof v == 'string') {
                 value = value.map(v => v.toString())


### PR DESCRIPTION
It seems like `transformWriteSet` will always throw `OneTableError` error if there will be array of strings for a field with type=Set.
[This line](https://github.com/sensedeep/dynamodb-onetable/blob/main/src/Model.js#L1535) is checking for `type == 'set'`, but `transformWriteSet` doesn't cover such case.

Example:
schema:
```
...
User: {
            pk:         { type: String, value: 'account#${accountId}' },
            sk:         { type: String, value: 'user#${email}' },
            accountId:  { type: String, required: true },
            id:         { type: String, generate: 'ulid', validate: Match.ulid },
            name:       { type: String, required: true, validate: Match.name },
            email:      { type: String, required: true, validate: Match.email, crypt: true },
            role:       { type: String, default: 'user', enum: ['admin', 'user']},
            guests: { type: Set },
...
```
code:
```
const user = await User.update({ accountId: '01G14F2HG4K8PGF1V4E5VPS706', email: 'roadrunner@acme.com', balance: 0, role: 'admin', guests: ['first', 'second'] });
```
error:
```
OneTableError: Unknown type
    at Model.transformWriteSet (file:///mnt/c/Users/ea_pyl/aurea/sococo/onetable/dist/mjs/Model.js:1516:19)
```