### PR TITLE
fix(types): enforce schema requirements during model create

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -258,7 +258,7 @@ export type AnyModel = {
 
 export class Model<T> {
     constructor(table: any, name: string, options?: ModelConstructorOptions);
-    create(properties: EntityParameters<T>, params?: OneParams): Promise<T>;
+    create(properties: T, params?: OneParams): Promise<T>;
     find(properties?: EntityParametersForFind<T>, params?: OneParams): Promise<Paged<T>>;
     get(properties: EntityParameters<T>, params?: OneParams): Promise<T | undefined>;
     load(properties: EntityParameters<T>, params?: OneParams): Promise<T | undefined>;


### PR DESCRIPTION
Currently, calls to `create` do not enforce that required parameters are present. `EntityParameters<T>` is wrapped in `Partial`, meaning all required parameters become optional.

So, for instance, with this config

```ts
import {Entity, Table} from 'dynamodb-onetable';

const Schema = {
  version: '1.0.0',
  indexes: {
    primary: {hash: 'pk', sort: 'sk'},
    gs1: {hash: 'gs1pk', sort: 'gs1sk'},
    gs2: {hash: 'gs2pk', sort: 'gs2sk'},
  },
  models: {
    User: {
      pk: {type: String, value: 'USER#${name}'},
      sk: {type: String, value: 'USER#${name}'},
      name: {type: String, required: true, unique: true},
    },
  } as const,
  params: {
    timestamps: true,
    isoDates: true,
    createdField: 'createdAt',
    updatedField: 'updatedAt',
  },
};

type UserType = Entity<typeof Schema.models.User>;

const table = new Table({
  name: 'user',
  schema: Schema,
});

const User = table.getModel<UserType>('User');
User.create({
  // name should be passed here because it's required
});
```

TypeScript will not complain about this missing `name` property, but a runtime validation error will be thrown:

```
OneTableError: Validation Error in "User" for "pk, sk, name"
    at Model.validateProperties (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:1402:25)
    at Model.collectProperties (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:1089:14)
    at Model.prepareProperties (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:1009:24)
    at Model.<anonymous> (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:521:49)
    at Generator.next (<anonymous>)
    at /Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:4:12)
    at Model.createUnique (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:509:16)
    at Model.<anonymous> (/Users/blimmer/code/dreamteam/dreamteam-backend/node_modules/dynamodb-onetable/dist/cjs/Model.js:497:37) {
  context: {
    validation: {
      pk: 'Value not defined for required field "pk"',
      sk: 'Value not defined for required field "sk"',
      name: 'Value not defined for required field "name"'
    }
  },
  code: 'ValidationError',
  date: 2022-05-23T15:45:30.251Z
}
```

However, `UserType` has enough information to detect this issue before runtime:

```ts
type UserType = {
    name: string;
    pk?: string | undefined;
    sk?: string | undefined;
}
```

By changing the `create` parameter as suggested in this PR, TypeScript can warn us that we're not passing a required parameter:

<img width="996" alt="Screen Shot 2022-05-23 at 09 47 19" src="https://user-images.githubusercontent.com/630449/169857797-aa051cbc-774d-4232-aa75-e583c951b87c.png">

<img width="462" alt="Screen Shot 2022-05-23 at 09 48 48" src="https://user-images.githubusercontent.com/630449/169858055-387a5fbf-e358-4cb4-96b8-0a322e28f10d.png">


This helps alert developers of application code that needs to be updated with schema mutations sooner.