### PR TITLE
Support types of nested objects

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -105,7 +105,7 @@ type EntityFieldFromType<T extends OneField> =
       T['type'] extends (ArrayConstructor | 'array') ? any[]
     : T['type'] extends (BooleanConstructor | 'boolean') ? boolean
     : T['type'] extends (NumberConstructor | 'number') ? number
-    : T['type'] extends (ObjectConstructor | 'object') ? object
+    : T['type'] extends (ObjectConstructor | 'object') ? Entity<T["schema"]>
     : T['type'] extends (DateConstructor | 'date') ? Date
     : T['type'] extends (ArrayBufferConstructor) ? ArrayBuffer
     : T['type'] extends (StringConstructor | 'string') ? string


### PR DESCRIPTION
This change will offer type hints for the object field type where a schema has been defined.

### Existing functionality:

Currently you would see the following when accessing an object type property:
![image](https://user-images.githubusercontent.com/1086841/170681571-c8772a7b-eccd-4080-b27c-813942933d7b.png)

And trying to access the street property on an address would cause a type error:
![image](https://user-images.githubusercontent.com/1086841/170681659-dcb43021-f002-4819-888a-722d7ab697aa.png)

### New functionality:

With this change objects that have a schema are now type complete:

![image](https://user-images.githubusercontent.com/1086841/170681321-dae0a2bb-99ae-431e-b79c-dc1e5d4c9b2f.png)

In a scenario where the `schema` field is not provided the type for an object field it would become `Entity<unknown>` which I think would be the correct behaviour.
