### PR TITLE
Allow non-required objects with required fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "author": "Michael O'Brien <mob@sensedeep.com>",
     "license": "MIT",
     "scripts": {
-        "build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && ./fixup",
+        "build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && bash ./fixup",
         "lint": "eslint src",
         "lint-fix": "eslint src --fix",
         "prepare": "npm run build",

--- a/src/Model.js
+++ b/src/Model.js
@@ -1109,7 +1109,10 @@ export class Model {
                     let name = field.name
                     let value = properties[name]
                     if (op == 'put') {
-                        value = value || field.default || {}
+                        value = value || field.default
+                        if (value === undefined && field.required) {
+                            value = {}
+                        }
                     }
                     if (value !== undefined) {
                         rec[name] = rec[name] || value


### PR DESCRIPTION
At present nested schemas cannot have required fields with a non-required parent. For example

```
{
   parent: {
      type: 'object',
      required: false,
      schema: {
        name:  {
          type: 'string',
          required: true
        }
      }
   }
}
```

Fails validation when parent is undefined.  This minor PR is my best guess at how to resolve this. 

It also has a small fix so it will build on Windows.