### PR TITLE
Break table definition out as its own function

### DIFF
--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -54,6 +54,7 @@ export class Table {
     batchGet(batch: any, params?: OneParams): Promise<{}[]>;
     batchWrite(batch: any, params?: OneParams): Promise<{}>;
     clearContext(): Table;
+    getTableDefinition(params?: {}): {};
     createTable(params?: {}): Promise<{}>;
     deleteTable(confirmation: string): Promise<{}>;
     describeTable(): Promise<{}>;

--- a/src/Table.js
+++ b/src/Table.js
@@ -198,10 +198,11 @@ export class Table {
     }
 
     /*
-        Create a DynamoDB table. Uses the current schema index definition.
+        Output the AWS table definition as a JSON structure to use in external tools such as CloudFormation
+        or the AWS CLI to create your DynamoDB table. Uses the current schema index definition.
         Alternatively, params may contain standard DynamoDB createTable parameters.
     */
-    async createTable(params = {}) {
+    getTableDefinition(params = {}) {
         let def = {
             AttributeDefinitions: [],
             KeySchema: [],
@@ -287,6 +288,15 @@ export class Table {
         if (def.LocalSecondaryIndexes.length == 0) {
             delete def.LocalSecondaryIndexes
         }
+        return def
+    }
+
+    /*
+        Create a DynamoDB table. Uses the current schema index definition.
+        Alternatively, params may contain standard DynamoDB createTable parameters.
+    */
+    async createTable(params = {}) {
+        const def = this.getTableDefinition(params)
         this.log.trace(`OneTable createTable for "${this.name}"`, {def})
         let result
         if (this.V3) {


### PR DESCRIPTION
Since the Table class already generates a definition description with createTable, it would be helpful to expose that functionality as a standalone method. When using infrastructure as code frameworks such as AWS CDK, Serverless, or Serverless Stack, this would be a great benefit to quickly generate the resource definition from a Onetable schema and table name. 

This pull request breaks the definition generation functionality of `Table.createTable()` out as `Table.getTableDefinition()`

Currently, the only way to do this programmatically is to mock a fake dynamodb client.

**Before:**
```javascript

const table = new Table({
  name: 'DynamoTable',
  schema: mySchema,
  // Stub in a createTable used to describe the table
  client: {
    V3: true,
    createTable(def) {
      return def
    },
  },
})

const definition = await table.createTable()
```

**After:**

```javascript

const table = new Table({
  name: 'DynamoTable',
  schema: mySchema,
})

const definition = table.getTableDefinition()
```

