### PR TITLE
Fixes scan/find count aggregation when paging

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -346,7 +346,7 @@ export class Model {
         /*
             Run command. Paginate if required.
          */
-        let pages = 0, items = []
+        let pages = 0, items = [], count = 0
         let maxPages = params.maxPages ? params.maxPages : SanityPages
         let result
         do {
@@ -370,6 +370,9 @@ export class Model {
             } else if (result.Attributes) {
                 items = [result.Attributes]
                 break
+            }
+            else if (params.count || params.select == 'COUNT') {
+                count += result.Count
             }
             if (params.progress) {
                 params.progress({items, pages, stats, params, cmd})
@@ -414,7 +417,7 @@ export class Model {
                 Object.defineProperty(items, 'next', {enumerable: false})
             }
             if (params.count || params.select == 'COUNT') {
-                items.count = result.Count
+                items.count = count
                 Object.defineProperty(items, 'count', {enumerable: false})
             }
             if (prev) {


### PR DESCRIPTION
When passing the option `count: true` to `find()`/`scan()` the count results are not aggregated when the record set exceeds DB limits and requires paging to get all record counts. Instead, the count result of the last page is returned.

This fix simply adds a `count` aggregation variable to `run()` and uses that as the return result instead of `result.Count`, which is only the count of records from the last query.

Note: the test required creating a bunch of large records to exceed DynamoDB's scan size limit to ensure `run()` has to page through results. It's not that bad but it may make sense to flag this test off?