### PR TITLE
i had this issue when trying it on my machine. this change fixed it

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you are using the AWS SDK V3, import the AWS V3 `DynamoDBClient` class and th
 Note: you can use the Table.setClient API to defer setting the client or replace the client at any time.
 
 ```javascript
-import Dynamo from 'dynamodb-onetable/Dynamo'
+import {Dynamo} from 'dynamodb-onetable/Dynamo'
 import {Model, Table} from 'dynamodb-onetable'
 import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
 const client = new Dynamo({client: new DynamoDBClient(params)})


### PR DESCRIPTION
```
const Dynamo = require('../node_modules/dynamodb-onetable/Dynamo');

const test = new Dynamo();
```

the above would give me the following error: `TypeError: Dynamo is not a constructor`. However, it was resolved with this small change
```
const {Dynamo} = require('../node_modules/dynamodb-onetable/Dynamo');

const test = new Dynamo();
```