### PR TITLE
fix(types): fix type error on models and table classes

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -102,12 +102,12 @@ type EntityFieldFromType<T extends OneField> =
       T['type'] extends (ArrayConstructor | 'array') ? ArrayItemType<T>[]
     : T['type'] extends (BooleanConstructor | 'boolean') ? boolean
     : T['type'] extends (NumberConstructor | 'number') ? number
-    : T['type'] extends (ObjectConstructor | 'object') ? Entity<T["schema"]>
+    : T['type'] extends (ObjectConstructor | 'object') ? Entity<Exclude<T["schema"], undefined>>
     : T['type'] extends (DateConstructor | 'date') ? Date
     : T['type'] extends (ArrayBufferConstructor) ? ArrayBuffer
     : T['type'] extends (StringConstructor | 'string') ? string
     : T['type'] extends (SetConstructor | 'set') ? Set<any>
-    : T['type'] extends 'typed-array' ? EntityFieldFromType<T["items"]>[]
+    : T['type'] extends 'typed-array' ? EntityFieldFromType<Exclude<T["items"], undefined>>[]
     : never;
 
 type ArrayItemType<T extends OneField> =

--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -48,7 +48,7 @@ type TableConstructorParams<Schema extends OneSchema> = {
     uuid?: (() => string) | string, //  Function to create a UUID if field schema requires it.
 };
 
-type ModelNames<Schema> = keyof Schema["models"];
+type ModelNames<Schema extends OneSchema> = keyof Schema["models"];
 type ExtractModel<M> = M extends Entity<infer X> ? X : never
 
 export class Table<Schema extends OneSchema = any> {


### PR DESCRIPTION
This change fixes the type declarations for the Model and Schema so that they _exclude_ `undefined` values. This is referenced in #393.

The error can be reproduced with a minimal project, here: https://github.com/skrud-dt/dynamodb-onetable-types-reproduce

The reason this is happening is that `'schema'` is defined on the `OneField` model as possibly being `undefined`, which causes TypeScript to complain about it. The workaround here is to just use `Exclude<T["schema"], undefined>` so that we're explicitly saying that "we want the type of `T["schema"]` that's not undefined".

To show that this works I fixed it in my reproduction example in this branch, using a patch. https://github.com/skrud-dt/dynamodb-onetable-types-reproduce/compare/main...fix-with-patch