### PR TITLE
Support for Converting DynamoDb stream records to New and Old model objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@aws-sdk/util-dynamodb": "^3.188.0"
             },
             "devDependencies": {
+                "@types/aws-lambda": "^8.10.108",
                 "@types/jest": "^29.1.2",
                 "@types/node": "^18.8.5",
                 "aws-sdk": "^2.1232.0",
@@ -2090,6 +2091,12 @@
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
             }
+        },
+        "node_modules/@types/aws-lambda": {
+            "version": "8.10.108",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.108.tgz",
+            "integrity": "sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==",
+            "dev": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.1.19",
@@ -7859,6 +7866,12 @@
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
             }
+        },
+        "@types/aws-lambda": {
+            "version": "8.10.108",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.108.tgz",
+            "integrity": "sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==",
+            "dev": true
         },
         "@types/babel__core": {
             "version": "7.1.19",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
         "@aws-sdk/util-dynamodb": "^3.188.0"
     },
     "devDependencies": {
+        "@types/aws-lambda": "^8.10.108",
         "@types/jest": "^29.1.2",
         "@types/node": "^18.8.5",
-        "utility-types": "^3.10.0",
         "aws-sdk": "^2.1232.0",
         "dataloader": "^2.1.0",
         "dynamo-db-local": "^4.1.3",
@@ -56,6 +56,7 @@
         "jest": "^29.1.2",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.4",
+        "utility-types": "^3.10.0",
         "wait-port": "^1.0.3"
     },
     "files": [

--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -5,10 +5,18 @@
 import {
     AnyEntity, AnyModel, Model, OneIndex, OneParams, OneProperties, OneModel, OneSchema, Paged, Entity
 } from "./Model";
+import { DynamoDBRecord } from "aws-lambda";
 
 export type EntityGroup = {
     [key: string]: AnyEntity[]
 };
+
+export type StreamEntityGroup = {
+    [key: string]: {
+        new?: AnyEntity,
+        old?: AnyEntity
+    }[]
+}
 
 type TableConstructorParams<Schema extends OneSchema> = {
     client?: {},                    //  Instance of DocumentClient or Dynamo.
@@ -115,4 +123,5 @@ export class Table<Schema extends OneSchema = any> {
 
     marshall(item: AnyEntity | AnyEntity[], params?: OneParams) : AnyEntity;
     unmarshall(item: AnyEntity | AnyEntity[], params?: OneParams) : AnyEntity;
+    stream(records: DynamoDBRecord[], params?: OneParams) : StreamEntityGroup;
 }

--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -13,6 +13,7 @@ export type EntityGroup = {
 
 export type StreamEntityGroup = {
     [key: string]: {
+        type: 'INSERT' | 'MODIFY' | 'REMOVE',
         new?: AnyEntity,
         old?: AnyEntity
     }[]

--- a/src/Table.js
+++ b/src/Table.js
@@ -12,7 +12,7 @@ import {Expression} from './Expression.js'
 import {Schema} from './Schema.js'
 import {Metrics} from './Metrics.js'
 import {OneTableArgError, OneTableError} from './Error.js'
-import { Converter } from 'aws-sdk/clients/dynamodb';
+import {Converter} from 'aws-sdk/clients/dynamodb'
 
 /*
     AWS V2 DocumentClient methods

--- a/src/Table.js
+++ b/src/Table.js
@@ -1119,6 +1119,8 @@ export class Table {
             return Converter.unmarshall(image)
         }
 
+        const tableModels = this.listModels()
+
         const result = {}
         for (const record of records) {
             if (!record.dynamodb.NewImage && !record.dynamodb.OldImage) {
@@ -1135,7 +1137,7 @@ export class Table {
                 typeNew = jsonNew[this.typeField]
 
                 // If type not found then don't do anything
-                if (typeNew) {
+                if (typeNew && tableModels.includes(typeNew)) {
                     model.new = this.schema.models[typeNew].transformReadItem(
                         'get', jsonNew, {}, params)
                 }
@@ -1147,7 +1149,7 @@ export class Table {
                 typeOld = jsonOld[this.typeField]
 
                 // If type not found then don't do anything
-                if (typeOld) {
+                if (typeOld && tableModels.includes(typeOld)) {
                     // If there was a new image of a different type then skip
                     if (typeNew && typeNew !== typeOld) {
                         continue

--- a/src/Table.js
+++ b/src/Table.js
@@ -1127,7 +1127,9 @@ export class Table {
                 continue
             }
 
-            const model = {}
+            const model = {
+                type: record.eventName
+            }
             let typeNew
             let typeOld
 

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -1,0 +1,152 @@
+import {Client, Table} from './utils/init'
+import {DynamoDBRecord} from "aws-lambda/trigger/dynamodb-stream";
+
+const table = new Table({
+    name: 'StreamTestTable',
+    client: Client,
+    partial: false,
+    schema: {
+        format: 'onetable:1.1.0',
+        version: '0.0.1',
+        indexes: {
+            primary: {hash: 'pk', sort: 'sk'},
+        },
+        models: {
+            User: {
+                pk: {type: String, value: '${_type}#${id}'},
+                sk: {type: String, value: '${_type}#'},
+                id: {type: String},
+                name: {type: String},
+                registered: {type: Date},
+                profile: {
+                    type: Object,
+                    schema: {
+                        dob: {type: Date},
+                    },
+                },
+            },
+        },
+        params: {
+            isoDates: true,
+            timestamps: true,
+        },
+    },
+})
+
+const event = {
+    Records: [
+        {
+            eventID: 'f07f8ca4b0b26cb9c4e5e77e42f274ee',
+            eventName: 'INSERT',
+            eventVersion: '1.1',
+            eventSource: 'aws:dynamodb',
+            awsRegion: 'us-east-1',
+            dynamodb: {
+                ApproximateCreationDateTime: 1480642020,
+                Keys: {
+                    val: {
+                        S: 'data'
+                    },
+                    key: {
+                        S: 'binary'
+                    }
+                },
+                NewImage: {
+                    _type: {S: 'User'},
+                    pk: {S: 'User#1234'},
+                    sk: {S: 'User#'},
+                    id: {S: '1234'},
+                    name: {S: 'alice'},
+                    registered: {S: '2022-01-01Z'},
+                    profile: {
+                        M: {
+                            dob: {S: '2000-01-01Z'},
+                        },
+                    },
+                },
+            },
+            eventSourceARN: 'arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000'
+        },
+        {
+            eventID: 'f07f8ca4b0b26cb9c4e5e77e42f274ee',
+            eventName: 'MODIFY',
+            eventVersion: '1.1',
+            eventSource: 'aws:dynamodb',
+            awsRegion: 'us-east-1',
+            dynamodb: {
+                ApproximateCreationDateTime: 1480642020,
+                Keys: {
+                    val: {
+                        S: 'data'
+                    },
+                    key: {
+                        S: 'binary'
+                    }
+                },
+                NewImage: {
+                    _type: {S: 'User'},
+                    pk: {S: 'User#1235'},
+                    sk: {S: 'User#'},
+                    id: {S: '1235'},
+                    name: {S: 'bob'},
+                    registered: {S: '2022-01-02Z'},
+                    profile: {
+                        M: {
+                            dob: {S: '1999-06-01Z'},
+                        },
+                    },
+                },
+                OldImage: {
+                    _type: {S: 'User'},
+                    pk: {S: 'User#1235'},
+                    sk: {S: 'User#'},
+                    id: {S: '1235'},
+                    name: {S: 'rob'},
+                    registered: {S: '2022-01-02Z'},
+                    profile: {
+                        M: {
+                            dob: {S: '1999-06-01Z'},
+                        },
+                    },
+                },
+                eventSourceARN: 'arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000'
+            }
+        }
+    ]
+}
+
+test('Stream has New Images', async () => {
+    const streamModels = table.stream(event.Records as DynamoDBRecord[]);
+    const newModels = streamModels.User.filter((streamModel) => !!streamModel.new)
+      .map((streamModel) => streamModel.new)
+
+    expect(newModels).toHaveLength(2);
+    expect(newModels[0]).toEqual(
+        expect.objectContaining({
+            id: '1234',
+            name: 'alice',
+            registered: new Date('2022-01-01Z'),
+        })
+    )
+    expect(newModels[1]).toEqual(
+      expect.objectContaining({
+          id: '1235',
+          name: 'bob',
+          registered: new Date('2022-01-02Z'),
+      })
+    )
+})
+
+test('Stream has Old Images', async () => {
+    const streamModels = table.stream(event.Records as DynamoDBRecord[]);
+    const oldModels = streamModels.User.filter((streamModel) => !!streamModel.old)
+      .map((streamModel) => streamModel.old)
+
+    expect(oldModels).toHaveLength(1);
+    expect(oldModels[0]).toEqual(
+      expect.objectContaining({
+          name: 'rob',
+          registered: new Date('2022-01-02Z'),
+      })
+    )
+})

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -111,6 +111,51 @@ const event = {
                 },
                 eventSourceARN: 'arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000'
             }
+        },
+        {
+            eventID: 'f07f8ca4b0b26cb9c4e5e77e42f274ee',
+            eventName: 'MODIFY',
+            eventVersion: '1.1',
+            eventSource: 'aws:dynamodb',
+            awsRegion: 'us-east-1',
+            dynamodb: {
+                ApproximateCreationDateTime: 1480642020,
+                Keys: {
+                    val: {
+                        S: 'data'
+                    },
+                    key: {
+                        S: 'binary'
+                    }
+                },
+                NewImage: {
+                    _type: {S: 'NonModel'},
+                    pk: {S: 'User#1235'},
+                    sk: {S: 'User#'},
+                    id: {S: '1235'},
+                    name: {S: 'bob'},
+                    registered: {S: '2022-01-02Z'},
+                    profile: {
+                        M: {
+                            dob: {S: '1999-06-01Z'},
+                        },
+                    },
+                },
+                OldImage: {
+                    _type: {S: 'NonModel'},
+                    pk: {S: 'User#1235'},
+                    sk: {S: 'User#'},
+                    id: {S: '1235'},
+                    name: {S: 'rob'},
+                    registered: {S: '2022-01-02Z'},
+                    profile: {
+                        M: {
+                            dob: {S: '1999-06-01Z'},
+                        },
+                    },
+                },
+                eventSourceARN: 'arn:aws:dynamodb:us-east-1:123456789012:table/Example-Table/stream/2016-12-01T00:00:00.000'
+            }
         }
     ]
 }

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -162,18 +162,19 @@ const event = {
 
 test('Stream has New Images', async () => {
     const streamModels = table.stream(event.Records as DynamoDBRecord[]);
-    const newModels = streamModels.User.filter((streamModel) => !!streamModel.new)
-      .map((streamModel) => streamModel.new)
+    const models = streamModels.User.filter((streamModel) => !!streamModel.new)
 
-    expect(newModels).toHaveLength(2);
-    expect(newModels[0]).toEqual(
+    expect(models).toHaveLength(2)
+    expect(models[0].type).toEqual('INSERT')
+    expect(models[0].new).toEqual(
         expect.objectContaining({
             id: '1234',
             name: 'alice',
             registered: new Date('2022-01-01Z'),
         })
     )
-    expect(newModels[1]).toEqual(
+    expect(models[1].type).toEqual('MODIFY')
+    expect(models[1].new).toEqual(
       expect.objectContaining({
           id: '1235',
           name: 'bob',
@@ -184,11 +185,11 @@ test('Stream has New Images', async () => {
 
 test('Stream has Old Images', async () => {
     const streamModels = table.stream(event.Records as DynamoDBRecord[]);
-    const oldModels = streamModels.User.filter((streamModel) => !!streamModel.old)
-      .map((streamModel) => streamModel.old)
+    const models = streamModels.User.filter((streamModel) => !!streamModel.old)
 
-    expect(oldModels).toHaveLength(1);
-    expect(oldModels[0]).toEqual(
+    expect(models).toHaveLength(1)
+    expect(models[0].type).toEqual('MODIFY')
+    expect(models[0].old).toEqual(
       expect.objectContaining({
           name: 'rob',
           registered: new Date('2022-01-02Z'),


### PR DESCRIPTION
I needed to be able to take DynamoDB streams and get the OneTable model objects from the records.

The code should support New Image, Old Image and New And Old Image view types. Keys only is not supported but I guess in theory code could be added to fetch the item from dynamodb, I didn't need this so didn't build it.

I found the `Table.unmarshall` method for sdk v2 didn't support the format of the stream record so the extra `unmarshallStreamImage` method I added inside the `stream` method