### PR TITLE
fix: OneField.encode typescript definition needs to allow for (string|number)

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -37,7 +37,7 @@ export type OneIndex = {
 export type OneField = {
     crypt?: boolean,
     default?: string | number | boolean | object,
-    encode?: readonly string[],
+    encode?: readonly (string | number)[],
     enum?: readonly string[],
     filter?: boolean,
     generate?: string | boolean,


### PR DESCRIPTION
per the docs, encode is supposed to follow a format of ['sk', '#', 1] which means it's a mix of strings and numbers