### PR TITLE
fix: Allow encode in typescript to use a RegExp for the deliminiter

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -37,7 +37,7 @@ export type OneIndex = {
 export type OneField = {
     crypt?: boolean,
     default?: string | number | boolean | object,
-    encode?: readonly (string | number)[],
+    encode?: readonly (string | RegExp | number)[],
     enum?: readonly string[],
     filter?: boolean,
     generate?: string | boolean,


### PR DESCRIPTION
For javascript it just implicitly allows that as an option to the split method.