### PR TITLE
fix: saveSchema breaks when supporting RegExp for encode

### DIFF
--- a/src/Schema.js
+++ b/src/Schema.js
@@ -286,6 +286,9 @@ export class Schema {
         if (field.validate && field.validate instanceof RegExp) {
             field.validate = `/${field.validate.source}/${field.validate.flags}`
         }
+        if (field.encode) {
+            field.encode = field.encode.map(e => (e instanceof RegExp) ? `/${e.source}/${e.flags}` : e)
+        }
         let type = (typeof field.type == 'function') ? field.type.name : field.type
         field.type = type.toLowerCase()
         //  DEPRECATE


### PR DESCRIPTION
needs to have the same logic applied to it as the field.validate