### PR TITLE
fix: passing `keyof Schema["model"]` to `table.getModel` caused type-error

### DIFF
--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -79,7 +79,8 @@ export class Table<Schema extends OneSchema = any> {
     generate(): string;
     getLog(): any;
     getKeys(): Promise<OneIndex>;
-    getModel<T>(name: T extends ModelNames<Schema> ? T : ModelNames<Schema>): T extends string ? Model<Entity<Schema["models"][T]>> : Model<Entity<ExtractModel<T>>>;
+    getModel<T extends ModelNames<Schema>>(name: T): Model<Entity<Schema["models"][T]>>;
+    getModel<T>(name: ModelNames<Schema>): Model<Entity<ExtractModel<T>>>;
     getCurrentSchema(): {};
     groupByType(items: AnyEntity[], params?: OneParams): EntityGroup;
     listModels(): AnyModel[];


### PR DESCRIPTION
Fixes issues like "TS2345: Argument of type 'string | number' is not assignable to parameter of type '(string extends keyof TSchema["models"] ? keyof TSchema["models"] & string : keyof TSchema["models"]) | (number extends keyof TSchema["models"] ? keyof TSchema["models"] & number : keyof TSchema["models"])'.   Type 'string' is not assignable to type '(string extends keyof TSchema["models"] ? keyof TSchema["models"] & string : keyof TSchema["models"]) | (number extends keyof TSchema["models"] ? keyof TSchema["models"] & number : keyof TSchema["models"])'." by splitting up the cases and make it easier for typescript to identify whether we want to use the type parameter for only declaring the model we wish to receive or use it to specify the name of the model in the schema which it should fetch from there.