### PR TITLE
fix: replace sdk v2 unmarshaller

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,6 @@ module.exports = {
         '!**/helpers.[jt]s',
         '!**/schemas/*',
         '!**/proto.ts',
-        '!**/stream.ts',
     ],
     globalSetup: '<rootDir>/test/utils/setup.ts',
     globalTeardown: '<rootDir>/test/utils/teardown.ts',


### PR DESCRIPTION
From this discussion - https://github.com/sensedeep/dynamodb-onetable/discussions/445#discussioncomment-4987730

I've removed the use of the sdk v2 converter. As the stream records are the same structure no matter what sdk you use I've opted to use the v3 unmarshall method as there is already a hard dependency of the v3 library that contains the unmarshall method and it performs the same as the v2 version.