### PR TITLE
FIX: oneschema array typings

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -36,7 +36,7 @@ export type OneIndex = {
  */
 export type OneField = {
     crypt?: boolean
-    default?: string | number | boolean | object | array
+    default?: string | number | boolean | object | Array<any>
     encode?: readonly (string | RegExp | number)[]
     enum?: readonly string[]
     filter?: boolean


### PR DESCRIPTION
Fix TypeScript (v4.9.5) error

tsconfig.json:
```json
  "compilerOptions": {
    "target": "es2022",
    "module": "commonjs",
    "moduleResolution": "node",
    "newLine": "lf",
    "strict": true,
    "strictPropertyInitialization": false,
    "strictNullChecks": true,
    "forceConsistentCasingInFileNames": true,
    "allowSyntheticDefaultImports": true,
    "esModuleInterop": true,
    "resolveJsonModule": true,
    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "removeComments": true
  }
```

build error:
![image](https://user-images.githubusercontent.com/48926119/223212542-8409c590-ffa6-4e53-aac0-b25e73841fa1.png)
