### PR TITLE
fix: consistent array syntax in type declaration

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -36,7 +36,7 @@ export type OneIndex = {
  */
 export type OneField = {
     crypt?: boolean
-    default?: string | number | boolean | object | Array<any>
+    default?: string | number | boolean | object | any[]
     encode?: readonly (string | RegExp | number)[]
     enum?: readonly string[]
     filter?: boolean


### PR DESCRIPTION
This is silly, but a necessary change to work with Microsoft's [rush](https://github.com/microsoft/rushstack) build tool. For some reason the `rush update` command transforms this declaration file into invalid syntax. Specifically line 39 in Model.d.ts is transformed into:

```typescript
    default?: string | number | boolean | object | array
```

Which produces the error:

```
Rush Multi-Project Build Tool 5.75.0 - Node.js 16.19.1 (LTS)
> "node_modules/.bin/build"

../../common/temp/node_modules/.pnpm/dynamodb-onetable/node_modules/dynamodb-onetable/dist/mjs/Model.d.ts:39:52 - error TS2552: Cannot find name 'array'. Did you mean 'Array'?

39     default?: string | number | boolean | object | array
                                                      ~~~~~

  ../../common/temp/node_modules/.pnpm/typescript@4.7.4/node_modules/typescript/lib/lib.es5.d.ts:1470:13
    1470 declare var Array: ArrayConstructor;
                     ~~~~~
    'Array' is declared here.


Found 1 error in ../../common/temp/node_modules/.pnpm/dynamodb-onetable@2.6.1/node_modules/dynamodb-onetable/dist/mjs/Model.d.ts:39
```

Another fix is possible - adding a semi-colon - but the change in this PR is more inline with this repo's code style.