### PR TITLE
Allow encoding of attributes to automatically fetch values without knowing separator or position

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -5,6 +5,7 @@
 */
 import {Expression} from './Expression.js'
 import {OneTableError, OneTableArgError} from './Error.js'
+import {getValueFromTemplate} from './utils.js'
 
 /*
     Ready / write tags for interceptions
@@ -1083,7 +1084,17 @@ export class Model {
             if (value === undefined) {
                 if (field.encode) {
                     let [att, sep, index] = field.encode
-                    value = (raw[att] || '').split(sep)[index]
+                    
+                    if (att && !sep && !index) {
+                        let attField = fields[att]
+                        if (attField && attField.value && raw[att]) {
+                            value = getValueFromTemplate(attField.value, raw[att], name)
+                        } else {
+                            value = undefined
+                        }
+                    } else {
+                        value = (raw[att] || '').split(sep)[index]
+                    }
                 }
                 if (value === undefined) {
                     continue

--- a/src/utils.js.ts
+++ b/src/utils.js.ts
@@ -1,0 +1,35 @@
+export const getValueFromTemplate = (template, value, field) => {
+    const regex = /\$\{[a-zA-Z1-9_]+}/gm
+    const matches = template.match(regex)
+
+    if (matches === null) {
+        return null
+    }
+
+    const placeholder = `\${${field}}`
+    const placeholderIndex = matches.indexOf(placeholder)
+
+    if (placeholderIndex === -1) {
+        return null
+    }
+
+    let templateSection = template
+    if (placeholderIndex > 0) {
+        const frontStart = templateSection.indexOf(matches[placeholderIndex - 1]) + matches[placeholderIndex - 1].length
+        templateSection = templateSection.slice(frontStart)
+    }
+
+    if (placeholderIndex < matches.length - 1) {
+        const endStart = templateSection.indexOf(matches[placeholderIndex + 1])
+        templateSection = templateSection.slice(0, endStart)
+    }
+
+    const [startStr, endStr] = templateSection.split(placeholder)
+    const startPlace = value.indexOf(startStr) + startStr.length
+
+    if (!endStr) {
+        return value.slice(startPlace)
+    }
+
+    return value.slice(startPlace, value.indexOf(endStr))
+}

--- a/src/utils.js.ts
+++ b/src/utils.js.ts
@@ -33,3 +33,48 @@ export const getValueFromTemplate = (template, value, field) => {
 
     return value.slice(startPlace, value.indexOf(endStr))
 }
+
+export const getValuesFromTemplate = (template, value) => {
+    const regex = /\$\{[a-zA-Z1-9_]+}/gm
+    const values = {}
+
+    const matches = template.match(regex)
+    if (matches === null) {
+        return values
+    }
+
+    const numMatches = matches.length
+
+    let remainingTemplate = template
+    let remainingValue = value
+
+    for (let placeholderIndex = 0; placeholderIndex < numMatches; placeholderIndex++) {
+        const placeholder = matches[placeholderIndex]
+        const field = placeholder.slice(2, -1)
+
+        let placeholderSection = remainingTemplate
+        const nextPlaceholder = matches[placeholderIndex + 1]
+        if (nextPlaceholder !== undefined) {
+            const nextIndex = placeholderSection.indexOf(nextPlaceholder)
+            placeholderSection = placeholderSection.slice(0, nextIndex)
+        }
+
+        let placeholderValue = remainingValue
+        const [startStr, endStr] = placeholderSection.split(placeholder)
+        const startPlace = remainingValue.indexOf(startStr) + startStr.length
+
+        if (startPlace > 0) {
+            placeholderValue = remainingValue.slice(startPlace)
+        }
+
+        if (endStr.length > 0) {
+            placeholderValue = placeholderValue.slice(0, placeholderValue.indexOf(endStr))
+        }
+        values[field] = placeholderValue
+
+        remainingTemplate = remainingTemplate.slice(startStr.length + placeholder.length)
+        remainingValue = remainingValue.slice(startPlace + placeholderValue.length)
+    }
+
+    return values
+}

--- a/src/utils.js.ts
+++ b/src/utils.js.ts
@@ -3,14 +3,14 @@ export const getValueFromTemplate = (template, value, field) => {
     const matches = template.match(regex)
 
     if (matches === null) {
-        return null
+        return undefined
     }
 
     const placeholder = `\${${field}}`
     const placeholderIndex = matches.indexOf(placeholder)
 
     if (placeholderIndex === -1) {
-        return null
+        return undefined
     }
 
     let templateSection = template

--- a/test/get-value-from-template.ts
+++ b/test/get-value-from-template.ts
@@ -1,5 +1,4 @@
-import {getValueFromTemplate} from "../src/utils.js";
-
+import {getValueFromTemplate, getValuesFromTemplate} from '../src/utils.js'
 
 describe('getValueFromTemplate', () => {
     const fieldsAndValues = [
@@ -9,9 +8,16 @@ describe('getValueFromTemplate', () => {
         {field: 'batchId', expected: '6ebe3440-a11f-4bfb-9fed-6df83867723e'},
     ]
 
-    test.each(fieldsAndValues)('Get $field value from template', async ({field, expected}) => {
+    test.each(fieldsAndValues)('Get $field value from verbose template', async ({field, expected}) => {
         const template = 'Account#${accountId}:Company#${companyId}:Product#${productId}:Batch#${batchId}'
         const value = 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e:Product#a82735a9-c088-42eb-93ec-dc14995a258c:Batch#6ebe3440-a11f-4bfb-9fed-6df83867723e'
+
+        expect(getValueFromTemplate(template, value, field)).toEqual(expected)
+    })
+
+    test.each(fieldsAndValues)('Get $field value from simple template', async ({field, expected}) => {
+        const template = '${accountId}#${companyId}#${productId}#${batchId}'
+        const value = 'f51929e3-ea3f-4693-8480-99584adc07d8#621be599-a4ed-4664-b5c3-2c30a8fde47e#a82735a9-c088-42eb-93ec-dc14995a258c#6ebe3440-a11f-4bfb-9fed-6df83867723e'
 
         expect(getValueFromTemplate(template, value, field)).toEqual(expected)
     })
@@ -28,5 +34,42 @@ describe('getValueFromTemplate', () => {
         const value = 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e'
 
         expect(getValueFromTemplate(template, value, 'productId')).toBeUndefined()
+    })
+})
+
+
+describe('getValuesFromTemplate', () => {
+    const testCases = [
+        {
+            template: 'Account#${accountId}:Company#${companyId}:Product#${productId}:Batch#${batchId}',
+            value: 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e:Product#a82735a9-c088-42eb-93ec-dc14995a258c:Batch#6ebe3440-a11f-4bfb-9fed-6df83867723e',
+            expected: {
+                'accountId': 'f51929e3-ea3f-4693-8480-99584adc07d8',
+                'companyId': '621be599-a4ed-4664-b5c3-2c30a8fde47e',
+                'productId': 'a82735a9-c088-42eb-93ec-dc14995a258c',
+                'batchId': '6ebe3440-a11f-4bfb-9fed-6df83867723e',
+            }
+        },
+        {
+            template: '${accountId}#${companyId}#${productId}#${batchId}',
+            value: 'f51929e3-ea3f-4693-8480-99584adc07d8#621be599-a4ed-4664-b5c3-2c30a8fde47e#a82735a9-c088-42eb-93ec-dc14995a258c#6ebe3440-a11f-4bfb-9fed-6df83867723e',
+            expected: {
+                'accountId': 'f51929e3-ea3f-4693-8480-99584adc07d8',
+                'companyId': '621be599-a4ed-4664-b5c3-2c30a8fde47e',
+                'productId': 'a82735a9-c088-42eb-93ec-dc14995a258c',
+                'batchId': '6ebe3440-a11f-4bfb-9fed-6df83867723e',
+            }
+        },
+    ]
+
+    test.each(testCases)('Get values from template', async ({template, value, expected}) => {
+        expect(getValuesFromTemplate(template, value)).toEqual(expected)
+    })
+
+    test('Get no values when template has no placeholders', () => {
+        const template = 'Account#{accountId}:NoPlaceholder'
+        const value = 'Account#{accountId}:NoPlaceholder'
+
+        expect(getValuesFromTemplate(template, value)).toEqual({})
     })
 })

--- a/test/get-value-from-template.ts
+++ b/test/get-value-from-template.ts
@@ -15,12 +15,12 @@ describe('getValueFromTemplate', () => {
         expect(getValueFromTemplate(template, value, field)).toEqual(expected)
     })
 
-    test.each(fieldsAndValues)('Get $field value from simple template', async ({field, expected}) => {
-        const template = '${accountId}#${companyId}#${productId}#${batchId}'
-        const value = 'f51929e3-ea3f-4693-8480-99584adc07d8#621be599-a4ed-4664-b5c3-2c30a8fde47e#a82735a9-c088-42eb-93ec-dc14995a258c#6ebe3440-a11f-4bfb-9fed-6df83867723e'
-
-        expect(getValueFromTemplate(template, value, field)).toEqual(expected)
-    })
+    // test.each(fieldsAndValues)('Get $field value from simple template', async ({field, expected}) => {
+    //     const template = '${accountId}#${companyId}#${productId}#${batchId}'
+    //     const value = 'f51929e3-ea3f-4693-8480-99584adc07d8#621be599-a4ed-4664-b5c3-2c30a8fde47e#a82735a9-c088-42eb-93ec-dc14995a258c#6ebe3440-a11f-4bfb-9fed-6df83867723e'
+    //
+    //     expect(getValueFromTemplate(template, value, field)).toEqual(expected)
+    // })
 
     test('Get undefined when template has no placeholders', () => {
         const template = 'Account#{accountId}:NoPlaceholder'

--- a/test/get-value-from-template.ts
+++ b/test/get-value-from-template.ts
@@ -1,0 +1,15 @@
+import {getValueFromTemplate} from "../src/utils.js";
+
+const fieldsAndValues = [
+    {field: 'accountId', expected: 'f51929e3-ea3f-4693-8480-99584adc07d8'},
+    {field: 'companyId', expected: '621be599-a4ed-4664-b5c3-2c30a8fde47e'},
+    {field: 'productId', expected: 'a82735a9-c088-42eb-93ec-dc14995a258c'},
+    {field: 'batchId', expected: '6ebe3440-a11f-4bfb-9fed-6df83867723e'},
+]
+
+test.each(fieldsAndValues)('Get value from template', async ({field, expected}) => {
+    const template = 'Account#${accountId}:Company#${companyId}:Product#${productId}:Batch#${batchId}'
+    const value = 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e:Product#a82735a9-c088-42eb-93ec-dc14995a258c:Batch#6ebe3440-a11f-4bfb-9fed-6df83867723e'
+
+    expect(getValueFromTemplate(template, value, field)).toEqual(expected)
+})

--- a/test/get-value-from-template.ts
+++ b/test/get-value-from-template.ts
@@ -1,15 +1,32 @@
 import {getValueFromTemplate} from "../src/utils.js";
 
-const fieldsAndValues = [
-    {field: 'accountId', expected: 'f51929e3-ea3f-4693-8480-99584adc07d8'},
-    {field: 'companyId', expected: '621be599-a4ed-4664-b5c3-2c30a8fde47e'},
-    {field: 'productId', expected: 'a82735a9-c088-42eb-93ec-dc14995a258c'},
-    {field: 'batchId', expected: '6ebe3440-a11f-4bfb-9fed-6df83867723e'},
-]
 
-test.each(fieldsAndValues)('Get value from template', async ({field, expected}) => {
-    const template = 'Account#${accountId}:Company#${companyId}:Product#${productId}:Batch#${batchId}'
-    const value = 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e:Product#a82735a9-c088-42eb-93ec-dc14995a258c:Batch#6ebe3440-a11f-4bfb-9fed-6df83867723e'
+describe('getValueFromTemplate', () => {
+    const fieldsAndValues = [
+        {field: 'accountId', expected: 'f51929e3-ea3f-4693-8480-99584adc07d8'},
+        {field: 'companyId', expected: '621be599-a4ed-4664-b5c3-2c30a8fde47e'},
+        {field: 'productId', expected: 'a82735a9-c088-42eb-93ec-dc14995a258c'},
+        {field: 'batchId', expected: '6ebe3440-a11f-4bfb-9fed-6df83867723e'},
+    ]
 
-    expect(getValueFromTemplate(template, value, field)).toEqual(expected)
+    test.each(fieldsAndValues)('Get $field value from template', async ({field, expected}) => {
+        const template = 'Account#${accountId}:Company#${companyId}:Product#${productId}:Batch#${batchId}'
+        const value = 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e:Product#a82735a9-c088-42eb-93ec-dc14995a258c:Batch#6ebe3440-a11f-4bfb-9fed-6df83867723e'
+
+        expect(getValueFromTemplate(template, value, field)).toEqual(expected)
+    })
+
+    test('Get undefined when template has no placeholders', () => {
+        const template = 'Account#{accountId}:NoPlaceholder'
+        const value = 'Account#{accountId}:NoPlaceholder'
+
+        expect(getValueFromTemplate(template, value, 'accountId')).toBeUndefined()
+    })
+
+    test('Get undefined when field not found in template', () => {
+        const template = 'Account#${accountId}:Company#${companyId}'
+        const value = 'Account#f51929e3-ea3f-4693-8480-99584adc07d8:Company#621be599-a4ed-4664-b5c3-2c30a8fde47e'
+
+        expect(getValueFromTemplate(template, value, 'productId')).toBeUndefined()
+    })
 })


### PR DESCRIPTION
This is still work in progress but just thought I'd put up what I got so far to see if there is any interest.

I was looking at using the encode feature to reduce attributes and have their values fetched from value template attributes.

The issue I had was I have two delimiters `#` and `:`, I use the `#` to denote the next following is an ID and then I use `:` for everything else. 

Example:
```
Account#${accountId}:Company#${companyId}:Product#${productId}:Batch#${batchId}
```

With the existing functionality this would not work with encode.

I wondered if it was possible to automatically get attribute values based on the template and the field name.

So this is what I have so far. The way it would work is it would switch to "auto" mode if you don't define a delimiter and position in the encode param but just give the attribute that has the value template.

Of course this would need careful use, for example if your template was `${id}-${anotherId}-${andAnotherId}` and all 3 IDs were UUIDs then it would probably return the wrong values as the `-` everywhere would cause problems with identifying where one placeholder ends and one starts. So it would be up to the developer to make sure they understood the limitations of this and planned accordingly.

I still need to:
- test thoroughly with some real data in a table
- improve the regex in the `getValueFromTemplate` method
- add more unit tests for the `getValueFromTemplate` method

Would appreciate any early feedback on:
- are you even interested in this 
- is the `utils.js` file the right place to put the method (I first put it on Model class but was difficult to unit test)
- my regex-fu is pretty bad, any advice to improving the regex in the method (think it's too restrictive right now)