### PR TITLE
fix: add back import of `unmarshall` as required in `unmarshallStreamImage`

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -12,6 +12,7 @@ import {Expression} from './Expression.js'
 import {Schema} from './Schema.js'
 import {Metrics} from './Metrics.js'
 import {OneTableArgError, OneTableError} from './Error.js'
+import {unmarshall} from '@aws-sdk/util-dynamodb'
 
 /*
     AWS V2 DocumentClient methods


### PR DESCRIPTION
Seems in the most recent commit on `main` this import was removed which breaks the build as it's required for support for stream images in sdk v2.