### PR TITLE
fix: incorrect handling of the `batchWrite` response meant unprocessed items never reprocessed

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -755,7 +755,7 @@ export class Table {
         Those will be handled here if possible.
     */
     async batchWrite(batch, params = {}) {
-        if (Object.getOwnPropertyNames(batch).length == 0) {
+        if (Object.getOwnPropertyNames(batch).length === 0) {
             return {}
         }
         let retries = 0,
@@ -763,9 +763,8 @@ export class Table {
         do {
             more = false
             let response = await this.execute(GenericModel, 'batchWrite', batch, {}, params)
-            let data = response.data
-            if (data && data.UnprocessedItems && Object.keys(data.UnprocessedItems).length) {
-                batch.RequestItems = data.UnprocessedItems
+            if (response && response.UnprocessedItems && Object.keys(response.UnprocessedItems).length) {
+                batch.RequestItems = response.UnprocessedItems
                 if (params.reprocess === false) {
                     return false
                 }


### PR DESCRIPTION
This one kept me up all week but I finally tracked down the issue. I was doing tests of batchWrites of 10000 items but it was never writing them all, would get to around 3,000 and start dropping items randomly. I spent ages rewriting our code thinking that could be the issue as the OneTable `batchWrite` method code looked fine. After exhausting that last night I rewrote the `batchWrite` method in typescript in our own code to go around the OneTable method and realised what the issue was.

It seems the handling of the response from the batchWrite expected there to be a `data` object in the response which there is not. This means `UnprocessedItems` was never found so never reprocessed. The blessings of typescript, it told me immediately that `data` didn't exist (why didn't I do this first? 😢).

I've not yet tested this on aws sdk v2 and there should probably be tests written that mock a dynamodb response that returns `UnprocessedItems`, but as it seems pretty serious bug I'm creating a PR now incase someone else wants to take over before I can get around to testing. For now I'm using our own method in our code base as getting to the bottom of this took some time and it's now time critical for us to get working code deployed.