### PR TITLE
Handle no schema on object fields as `Record<any, any>`

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -110,7 +110,7 @@ type EntityFieldFromType<T extends OneField> = T['type'] extends ArrayConstructo
     : T['type'] extends NumberConstructor | 'number'
     ? number
     : T['type'] extends ObjectConstructor | 'object'
-    ? Entity<Exclude<T['schema'], undefined>>
+    ? (T['schema'] extends object ? Entity<Exclude<T['schema'], undefined>> : Record<any, any>)
     : T['type'] extends DateConstructor | 'date'
     ? Date
     : T['type'] extends ArrayBufferConstructor


### PR DESCRIPTION
When defining an object, it is useful to be able to not define the schema for the object and leave it open.  We use this often for key value maps of non critical data, usually we use `facts` as the field name for this.  e.g.

```
[...]
facts: {
  type: 'object',
  required: true
},
[...]
```

However, this results in facts being considered `unknown` and therefore not assignable or accessible without tricks such as type predicates or type assertions.  For example, this gives a typescript syntax highlighting error in vscode like:

```
resource.facts.abc = '123'
Property 'facts' does not exist on type 'Flatten<Merge<Required<unknown>, OptionalOrUndefined<unknown>>>'.
```

My overall preference would be to support more schema/type control over such open objects, however, that would be a much bigger change - it may be possible to define a type in the schema and somehow pass that through to `EntityFieldFromType` but I couldn’t find a way to do this.

I feel the right approach for now with minimal change is to change the handling in `EntityFieldFromType` such that when an object definition has no schema it is considered to be an “open” object. e.g. `Record<any, any>`.

Note that this only changes the type inference for object types with no schema at all, other declarations are unaffected, e.g.

```
[...]
facts: {
  type: 'object',
  required: true,
  schema: { }
},
[...]
```

Not that this definition is particularly useful :)