### PR TITLE
Add (multidimensional) enum array typing

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -100,7 +100,9 @@ export type OneSchemaParams = {
 /*
     Entity field signature generated from the schema
  */
-type EntityField<T extends OneField> = T['enum'] extends readonly EntityFieldFromType<T>[]
+type EntityField<T extends OneField> = T['items'] extends object
+  ? EntityField<T['items']>[]
+  : T['enum'] extends readonly EntityFieldFromType<T>[]
     ? T['enum'][number]
     : EntityFieldFromType<T>
 

--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -126,7 +126,7 @@ type EntityFieldFromType<T extends OneField> = T['type'] extends ArrayConstructo
 
 type ArrayItemType<T extends OneField> = T extends {items: OneField}
     ? EntityField<T['items']>
-    : EntityFieldFromType<T>
+    : any
 /*
     Select the required properties from a model
 */

--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -100,11 +100,13 @@ export type OneSchemaParams = {
 /*
     Entity field signature generated from the schema
  */
-type EntityField<T extends OneField> = T['items'] extends object
-  ? EntityField<T['items']>[]
-  : T['enum'] extends readonly EntityFieldFromType<T>[]
-    ? T['enum'][number]
-    : EntityFieldFromType<T>
+type EntityField<T extends OneField> = T['type'] extends 'array' | ArrayConstructor | ArrayBufferConstructor
+    ? T['items'] extends object
+        ? EntityField<T['items']>[]
+        : EntityFieldFromType<T>
+    : T['enum'] extends readonly EntityFieldFromType<T>[]
+        ? T['enum'][number]
+        : EntityFieldFromType<T>
 
 type EntityFieldFromType<T extends OneField> = T['type'] extends ArrayConstructor | 'array'
     ? ArrayItemType<T>[]

--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -100,13 +100,9 @@ export type OneSchemaParams = {
 /*
     Entity field signature generated from the schema
  */
-type EntityField<T extends OneField> = T['type'] extends 'array' | ArrayConstructor | ArrayBufferConstructor
-    ? T['items'] extends object
-        ? EntityField<T['items']>[]
-        : EntityFieldFromType<T>
-    : T['enum'] extends readonly EntityFieldFromType<T>[]
-        ? T['enum'][number]
-        : EntityFieldFromType<T>
+type EntityField<T extends OneField> = T['enum'] extends readonly EntityFieldFromType<T>[]
+    ? T['enum'][number]
+    : EntityFieldFromType<T>
 
 type EntityFieldFromType<T extends OneField> = T['type'] extends ArrayConstructor | 'array'
     ? ArrayItemType<T>[]
@@ -128,7 +124,9 @@ type EntityFieldFromType<T extends OneField> = T['type'] extends ArrayConstructo
     ? EntityFieldFromType<Exclude<T['items'], undefined>>[]
     : never
 
-type ArrayItemType<T extends OneField> = T extends {items: OneField} ? EntityFieldFromType<T['items']> : any
+type ArrayItemType<T extends OneField> = T extends {items: OneField}
+    ? EntityField<T['items']>
+    : EntityFieldFromType<T>
 /*
     Select the required properties from a model
 */

--- a/test/array-items.ts
+++ b/test/array-items.ts
@@ -1,5 +1,6 @@
-import {Client, Table} from './utils/init'
+import {Client, Entity, Table} from './utils/init'
 import {ArrayItemsSchema} from './schemas'
+import { ColorEnum } from './schemas/arrayItemsSchema'
 
 // jest.setTimeout(7200 * 1000)
 
@@ -14,6 +15,7 @@ const table = new Table({
 const expected = {
     id: '1111-2222',
     arrayWithTypedItems: [{bar: 'Bar', when: new Date()}],
+    arrayWithEnumItems: [ColorEnum.blue, ColorEnum.red, ColorEnum.white],
     arrayWithoutTypedItems: ['a', '2', 3, new Date()],
 }
 
@@ -34,6 +36,7 @@ test('Create', async () => {
     expect(item.arrayWithTypedItems).toBeDefined()
     expect(item.arrayWithTypedItems.length).toBe(1)
     expect(item.arrayWithTypedItems[0].bar).toBe('Bar')
+    expect(item.arrayWithEnumItems).toBe(expected.arrayWithEnumItems)
     expect(item.arrayWithoutTypedItems.length).toBe(4)
     expect(item.arrayWithoutTypedItems[0]).toBe('a')
 
@@ -61,3 +64,11 @@ test('Destroy Table', async () => {
     await table.deleteTable('DeleteTableForever')
     expect(await table.exists()).toBe(false)
 })
+
+test('Array with enum items typing', () => {
+    type ArrayWithEnumItemsType = Entity<typeof ArrayItemsSchema.models.TestModel>['arrayWithEnumItems'];
+    const validA: ColorEnum[]|undefined = {} as ArrayWithEnumItemsType;
+    const validB: ArrayWithEnumItemsType = {} as ColorEnum[]|undefined;
+    // @ts-expect-error
+    const invalid: ArrayWithEnumItemsType = {} as string[]|undefined;
+});

--- a/test/array-items.ts
+++ b/test/array-items.ts
@@ -36,7 +36,7 @@ test('Create', async () => {
     expect(item.arrayWithTypedItems).toBeDefined()
     expect(item.arrayWithTypedItems.length).toBe(1)
     expect(item.arrayWithTypedItems[0].bar).toBe('Bar')
-    expect(item.arrayWithEnumItems).toBe(expected.arrayWithEnumItems)
+    expect(item.arrayWithEnumItems).toStrictEqual(expected.arrayWithEnumItems)
     expect(item.arrayWithoutTypedItems.length).toBe(4)
     expect(item.arrayWithoutTypedItems[0]).toBe('a')
 

--- a/test/schemas/arrayItemsSchema.ts
+++ b/test/schemas/arrayItemsSchema.ts
@@ -2,6 +2,12 @@
     Schema to test items property for array type
  */
 
+export enum ColorEnum {
+    red = 'red',
+    white = 'white',
+    blue = 'blue'
+}
+
 export default {
     version: '0.0.1',
     format: 'onetable:1.1.0',
@@ -24,6 +30,13 @@ export default {
                         bar: {type: String},
                         when: {type: Date},
                     },
+                },
+            },
+            arrayWithEnumItems: {
+                type: Array,
+                items: {
+                    type: String,
+                    enum: Object.values(ColorEnum),
                 },
             },
             arrayWithoutTypedItems: {type: Array, required: true},


### PR DESCRIPTION
### Context
Assume we have the following schema:
```ts
export const TheSchema {
	...,
	models: {
	    SomeModel: {
	        brands: {
	            type: Array,
                    required: true,
	            items: {
                        type: String,
	                enum: Object.values(Brand)
	            }
	        }
	    }
	}
}
```
the following Entity type:
```ts
export type SomeModelEntity = Entity<typeof TheSchema.models.SomeModel>;
```
and the following code:
```ts
const {brands}: SomeModelEntity = {
	...
}
```

### Previously
when we check the type of `brands` we're seeing that it has the type `string[]` instead of the type `Brand[]`

### New
When we check the type of `brands` we'll see that it has type `Brand[]`