### PR TITLE
fix: include null typing for nulls field param

### DIFF
--- a/src/Model.d.ts
+++ b/src/Model.d.ts
@@ -150,7 +150,9 @@ type OptionalOrNull<T extends OneModel> = {
     -readonly [P in keyof T as T[P]['required'] extends true ? never : P]?: EntityField<T[P]> | null
 }
 type OptionalOrUndefined<T extends OneModel> = {
-    -readonly [P in keyof T as T[P]['required'] extends true ? never : P]?: EntityField<T[P]> | undefined
+    -readonly [P in keyof T as T[P]['required'] extends true ? never : P]?: T[P]['nulls'] extends true
+        ? EntityField<T[P]> | null | undefined 
+        : EntityField<T[P]> | undefined
 }
 
 /*


### PR DESCRIPTION
This PR addresses https://github.com/sensedeep/dynamodb-onetable/issues/555

Issue: fields do not include a null type when nulls === true. 
Solution: Adjusted `src/Model.d.ts` to checking nulls param, only when required is not true.
